### PR TITLE
clone items object 

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -153,7 +153,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 		}
 
 		// Populate each object we are sorting with a sort value.
-		$this->populateSortValues($items);
+		$this->populateSortValues(clone $items);
 
 		// Generate the current sort values.
 		$current = $items->map('ID', $field)->toArray();


### PR DESCRIPTION
BUGFIX clone the $items DataList object before performing the populateSortValues method on it, as we don't want it manipulated for the operations to follow.... which was causing the following error for me

ERROR [Notice]: Undefined index: 2
IN POST /admin/pages/edit/EditForm/field/Advertisments/reorder
Line 234 in /Users/sheadawson/htdocs/aecl-ss3/gridfieldextensions/code/GridFieldOrderableRows.php
