### PR TITLE
MINOR: better Config for inline editable grid

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -23,11 +23,12 @@ $grid = new GridField(
 	'ExampleGrid',
 	'Example Grid',
 	$this->Items(),
-		GridFieldConfig_RecordEditor::create()
-			->removeComponentsByType('GridFieldAddNewButton')
-			->removeComponentsByType('GridFieldDataColumns')
-			->addComponent(new GridFieldEditableColumns(), 'GridFieldEditButton')
-			->addComponent(new GridFieldAddNewInlineButton())
+	GridFieldConfig::create()
+		->addComponent(new GridFieldButtonRow('before'))
+		->addComponent(new GridFieldToolbarHeader())
+		->addComponent(new GridFieldEditableColumns())
+		->addComponent(new GridFieldDeleteAction())
+		->addComponent(new GridFieldAddNewInlineButton())
 );
 ```
 


### PR DESCRIPTION
The docs should only provide such a basic, fully working example

the removed example showed using the GridFieldConfit_RecordEditor which included components that are not playing nicely together with GridFieldEditableColumns
- The sort, filter and pagination components reload the grid when they perform an action, therefore all filled out text fields will be reset and all modifications done by the admin are lost
- in most cases you don't want the edit button if you already have inline editing
