### PR TITLE
FIX: Include .action class to add margin styles

### DIFF
--- a/templates/GridFieldAddExistingSearchButton.ss
+++ b/templates/GridFieldAddExistingSearchButton.ss
@@ -1,3 +1,3 @@
-<a href="$Link" class="ss-ui-button ui-button add-existing-search" data-icon="magnifier">
+<a href="$Link" class="action ss-ui-button ui-button add-existing-search" data-icon="magnifier">
 	$Title
 </a>


### PR DESCRIPTION
Currently the styling for the `GridFieldAddExistingSearchButton` seems to be missing any bottom or right spacing. This is easily fixed by adding the `action` class.

Before:
![screen shot 2013-10-29 at 16 38 27](https://f.cloud.github.com/assets/842280/1429832/d7627284-40b8-11e3-86d0-b204976ddd38.png)

After:
![screen shot 2013-10-29 at 16 37 55](https://f.cloud.github.com/assets/842280/1429834/de77b638-40b8-11e3-8700-0c4b4e39bc03.png)
