### PR TITLE
GridFieldAddNewMultiClass: Make relation property available in CreateForm

### DIFF
--- a/code/GridFieldAddNewMultiClass.php
+++ b/code/GridFieldAddNewMultiClass.php
@@ -129,8 +129,15 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 			throw new SS_HTTPResponse_Exception(400);
 		}
 
+		$record = new $class();
+		$List = $grid->getList();
+		if ($List && $List->is_a('HasManyList')) {
+			$fk = $List->getForeignKey();
+			$record->$fk = $List->getForeignID();
+		}
+		
 		$handler = new GridFieldAddNewMultiClassHandler(
-			$grid, $component, new $class(), $grid->getForm()->getController(), 'add-multi-class'
+			$grid, $component, $record, $grid->getForm()->getController(), 'add-multi-class'
 		);
 		$handler->setTemplate($component->getTemplate());
 


### PR DESCRIPTION
Hi,

Normally the relation of the DataObject is stored after the DataObject is written the first time.

With this patch the default value of your relation is populated to the create form, before it's created.
=> $this->YourHasManyRelation() works in getCMSFields()

Cheers,

Malte
