### PR TITLE
BUG: Prevents a warning being thrown when reordering.

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -62,9 +62,11 @@ class GridFieldOrderableRows extends RequestHandler implements
 		if($list instanceof ManyManyList) {
 			$extra = $list->getExtraFields();
 			$table = $list->getJoinTable();
-
-			if(array_key_exists($field, $extra)) {
-				return $table;
+			
+			if(isset($extra)) {
+				if(array_key_exists($field, $extra)) {
+					return $table;
+				}	
 			}
 		}
 
@@ -279,8 +281,10 @@ class GridFieldOrderableRows extends RequestHandler implements
 			$extra = $list->getExtraFields();
 			$key   = $list->getLocalKey();
 
-			if(array_key_exists($this->getSortField(), $extra)) {
-				return sprintf('"%s" %s', $key, $value);
+			if(isset($extra)) {
+				if(array_key_exists($this->getSortField(), $extra)) {
+					return sprintf('"%s" %s', $key, $value);
+				}
 			}
 		}
 


### PR DESCRIPTION
Sorry mate, I have been away for a couple of weeks and missed your message on the first pull request for this and it was closed before I could respond.

I was getting the following in the black box at the top right of screen and a broken page in the admin: Warning at line 67 of MYPATH/website/gridfieldextensions/code/GridFieldOrderableRows.php. 

Adding the isset check made the error messages go away and made things a lot smoother when creating content.

Any chance this could be merged?
