### PR TITLE
Check from ExtraFields in getSortTableClauseForIds

### DIFF
--- a/code/GridFieldOrderableRows.php
+++ b/code/GridFieldOrderableRows.php
@@ -281,7 +281,7 @@ class GridFieldOrderableRows extends RequestHandler implements
 			$foreignKey = $list->getForeignKey();
 			$foreignID  = $list->getForeignID();
 
-			if(array_key_exists($this->getSortField(), $extra)) {
+			if($extra && array_key_exists($this->getSortField(), $extra)) {
 				return sprintf(
 					'"%s" %s AND "%s" = %d',
 					$key,


### PR DESCRIPTION
if no extrafields are on the many_many relationship error generated same fix as chillu on getSortTable
