### PR TITLE
Don't add an empty field to the AddMultiClass DD

### DIFF
--- a/code/GridFieldAddNewMultiClass.php
+++ b/code/GridFieldAddNewMultiClass.php
@@ -150,7 +150,7 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
 		GridFieldExtensions::include_requirements();
 
 		$field = new DropdownField(sprintf('%s[ClassName]', __CLASS__), '', $classes);
-		$field->setEmptyString(_t('GridFieldExtensions.SELECTTYPETOCREATE', '(Select type to create)'));
+		//$field->setEmptyString(_t('GridFieldExtensions.SELECTTYPETOCREATE', '(Select type to create)'));
 		$field->addExtraClass('no-change-track');
 
 		$data = new ArrayData(array(


### PR DESCRIPTION
What do you think about removing this line? When i use this module, i find it annying to have to select an item - i would rather that it defaults to an item.
