### PR TITLE
Drag handle icon is always visible

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -117,17 +117,29 @@
 }
 
 .ss-gridfield-orderable .col-reorder {
+	position: relative;
 	padding: 0 !important;
 	width: 16px !important;
 }
 
 .ss-gridfield-orderable .col-reorder .handle {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
 	cursor: move;
-	display: none;
 }
 
-.ss-gridfield-orderable tbody tr:hover .col-reorder .handle {
-	display: block;
+.ss-gridfield-orderable .col-reorder .handle .icon {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	width: 5px;
+	height: 11px;
+	margin: -5px 0 0 -2px;
+	background-image: url('../../framework/thirdparty/jquery-ui-themes/smoothness/images/ui-icons_222222_256x240.png');
+	background-position: -5px -227px;
 }
 
 .ss-gridfield-orderhelper {

--- a/templates/GridFieldOrderableRowsDragHandle.ss
+++ b/templates/GridFieldOrderableRowsDragHandle.ss
@@ -1,1 +1,1 @@
-<span class="handle ui-icon ui-icon-grip-dotted-vertical"></span>
+<span class="handle"><span class="icon"></span></span>


### PR DESCRIPTION
This makes the drag handle icon always visible. Always found it confusing to have an empty cell on the left and having to hover the cell to know that's where the drag handle is.

Also, this makes the whole `.col-reorder` cell interactive for dragging so it can't be missed and accidentally take you to the edit form.
