### PR TITLE
support and cast relationship references as ReadonlyField

### DIFF
--- a/code/GridFieldEditableColumns.php
+++ b/code/GridFieldEditableColumns.php
@@ -30,7 +30,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
 
 		$fields = $this->getForm($grid, $record)->Fields();
 		$value  = $grid->getDataFieldValue($record, $col);
-		$rel    = (strpos($col,'.') == false); // field references a relation value
+		$rel    = (strpos($col,'.') === false); // field references a relation value
 		$field  = ($rel) ? clone $fields->fieldByName($col) : new ReadonlyField($col);
 
 		if(!$field) {


### PR DESCRIPTION
Allows relationship fields and casts as ReadonlyField by default. Before a fatal error would occur when trying to clone a non object.  

Example;

``` php
class Attachment extends DataObject {
    private static $db = array(
        'Title' => 'Varchar',
    );

    private static $has_one = array(
        'File' => 'File'
    );

    private static $summary_fields = array(
        'Title' => 'Title',
        'File.Name' => 'File Name',
        'File.Size' => 'File Size',
        'File.FileType' => 'File Type'
    );
}

....

//EditableGridfield usage:

$grid_config->getComponentByType('GridFieldEditableColumns')->setDisplayFields(
  array(
    'Title' => array(
      'title' => 'Title',
      'field' => 'TextField'
    ),
    'File.Name' => array(
      'title' => 'File Name'
    ),
    'File.Size' => array(
      'title' => 'File Size'
    )
   // ...
);
```

Reference: PR #58 
