### PR TITLE
Added GridFieldSaveRow and GridFieldDuplicateRow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/nbproject

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This module provides a number of useful grid field components:
 * `GridFieldAddNewMultiClass` - lets the user select from a list of classes to
   create a new record from.
 * `GridFieldEditableColumns` - allows inline editing of records.
+* `GridFieldSaveRow` - allows to save inline edited record, also inside a ModelAdmin.
+* `GridFieldDuplicateRow` - allows to duplicate a record.
 * `GridFieldOrderableRows` - drag and drop re-ordering of rows.
 * `GridFieldRequestHandler` - a basic utility class which can be used to build
   custom grid field detail views including tabs, breadcrumbs and other CMS

--- a/code/GridFieldDuplicateRow.php
+++ b/code/GridFieldDuplicateRow.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Duplicate the selected row
+ *
+ * @author Gabriele Brosulo <gabriele@brosulo.net>
+ * @creation-date 21-apr-2017
+ */
+class GridFieldDuplicateRow implements GridField_ColumnProvider, GridField_ActionProvider {
+    /* ******************************
+     * ** GridField_ColumnProvider **
+     * ******************************/
+
+    public function augmentColumns($gridField, &$columns) {
+        if (!in_array('Actions', $columns)) {
+            $columns[] = 'Actions';
+        }
+    }
+
+    public function getColumnAttributes($gridField, $record, $columnName) {
+        return array('class' => 'col-buttons');
+    }
+
+    public function getColumnMetadata($gridField, $columnName) {
+        if ($columnName == 'Actions') {
+            return array('title' => '');
+        }
+    }
+
+    public function getColumnsHandled($gridField) {
+        return array('Actions');
+    }
+
+    public function getColumnContent($gridField, $record, $columnName) {
+        if (!$record->canEdit())
+            return;
+
+        $field = GridField_FormAction::create(
+                        $gridField, 'DuplicateRow' . $record->ID, 'Clone', "duplicaterow", array('RecordID' => $record->ID)
+        );
+
+        return $field->Field();
+    }
+
+    /* *****************************
+     * **GridField_ActionProvider **
+     * ******************************/
+
+    public function getActions($gridField) {
+        return array('duplicaterow');
+    }
+
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data) {
+
+        if ($actionName == 'duplicaterow') {
+
+            $model = $gridField->getModelClass();
+            $modified = $data[$model]['GridFieldEditableColumns'];
+
+            $obj = DataObject::get_by_id($model, $arguments['RecordID']);
+            $obj->duplicate();
+
+            // output a success message to the user
+            Controller::curr()->getResponse()->setStatusCode(
+                    200, 'Duplicate Record Done.'
+            );
+        }
+    }
+
+}

--- a/code/GridFieldDuplicateRow.php
+++ b/code/GridFieldDuplicateRow.php
@@ -55,7 +55,6 @@ class GridFieldDuplicateRow implements GridField_ColumnProvider, GridField_Actio
         if ($actionName == 'duplicaterow') {
 
             $model = $gridField->getModelClass();
-            $modified = $data[$model]['GridFieldEditableColumns'];
 
             $obj = DataObject::get_by_id($model, $arguments['RecordID']);
             $obj->duplicate();

--- a/code/GridFieldSaveRow.php
+++ b/code/GridFieldSaveRow.php
@@ -39,6 +39,7 @@ class GridFieldSaveRow implements GridField_ColumnProvider, GridField_ActionProv
         $field = GridField_FormAction::create(
                         $gridField, 'SaveRow' . $record->ID, 'Save', "saverow", array('RecordID' => $record->ID)
         );
+        $field->setAttribute('onclick', 'GFEremoveChanged()');
 
         return $field->Field();
     }

--- a/code/GridFieldSaveRow.php
+++ b/code/GridFieldSaveRow.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Add a save button, that saves inline columns modified by 
+ * GridFieldEditableColumns
+ *
+ * @author Gabriele Brosulo <gabriele@brosulo.net>
+ * @creation-date 21-apr-2017
+ */
+class GridFieldSaveRow implements GridField_ColumnProvider, GridField_ActionProvider {
+    /* ******************************
+     * ** GridField_ColumnProvider **
+     * ******************************/
+
+    public function augmentColumns($gridField, &$columns) {
+        if (!in_array('Actions', $columns)) {
+            $columns[] = 'Actions';
+        }
+    }
+
+    public function getColumnAttributes($gridField, $record, $columnName) {
+        return array('class' => 'col-buttons');
+    }
+
+    public function getColumnMetadata($gridField, $columnName) {
+        if ($columnName == 'Actions') {
+            return array('title' => '');
+        }
+    }
+
+    public function getColumnsHandled($gridField) {
+        return array('Actions');
+    }
+
+    public function getColumnContent($gridField, $record, $columnName) {
+        if (!$record->canEdit())
+            return;
+
+        $field = GridField_FormAction::create(
+                        $gridField, 'SaveRow' . $record->ID, 'Save', "saverow", array('RecordID' => $record->ID)
+        );
+
+        return $field->Field();
+    }
+
+    /* *****************************
+     * **GridField_ActionProvider **
+     * ******************************/
+
+    public function getActions($gridField) {
+        return array('saverow');
+    }
+
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data) {
+
+        if ($actionName == 'saverow') {
+
+            $model = $gridField->getModelClass();
+
+            $obj = DataObject::get_by_id($model, $arguments['RecordID']);
+            foreach ($data[$model]['GridFieldEditableColumns'][$arguments['RecordID']] as $c => $v) {
+                $obj->{$c} = $v;
+            }
+            $obj->write();
+
+            // output a success message to the user
+            Controller::curr()->getResponse()->setStatusCode(
+                    200, 'Save Record Done.'
+            );
+        }
+    }
+
+}

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -1,3 +1,8 @@
+function GFEremoveChanged() {
+    var form = jQuery('.cms-edit-form');
+    form.removeClass('changed');
+}
+
 (function($) {
 	$.entwine("ss", function($) {
 		/**


### PR DESCRIPTION
`GridFieldSaveRow` - allows to save inline edited record, also inside a ModelAdmin.
`GridFieldDuplicateRow` - allows to duplicate a record.

Fixes https://github.com/silverstripe-australia/silverstripe-gridfieldextensions/issues/89