### PR TITLE
FIX Remove references to Object, replace with Injector calls

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -4,7 +4,7 @@ namespace Symbiote\GridFieldExtensions;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPResponse_Exception;
-use SilverStripe\Core\Object;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
 use SilverStripe\Forms\FormField;
@@ -219,7 +219,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
                 $extra = $list->getExtraFields();
 
                 if ($extra && array_key_exists($col, $extra)) {
-                    $field = Object::create_from_string($extra[$col], $col)->scaffoldFormField();
+                    $field = Injector::inst()->create($extra[$col], $col)->scaffoldFormField();
                 }
             }
 


### PR DESCRIPTION
[Object has been removed](https://docs.silverstripe.org/en/4/changelogs/4.0.0/#replace-usages-of-object-class), this PR replaces its implementations.

Also updates a component string class name to FCQN to prevent the add new inline button component from failing.