### PR TITLE
FIX Update selector for editable columns Javascript handler to match GridField.js in core

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -250,7 +250,7 @@
 		 * GridFieldEditableColumns
 		 */
 
-		$('.ss-gridfield.ss-gridfield-editable .ss-gridfield-item td').entwine({
+		$('.grid-field .ss-gridfield-item').entwine({
 			onclick: function(e) {
 				// Prevent the default row click action when clicking a cell that contains a field
 				if (this.find('.editable-column-field').length) {


### PR DESCRIPTION
The selector in the core Javascript has changed, so the existing logic fails to prevent the default behaviour (go to edit form on click).

Reference: https://github.com/silverstripe/silverstripe-admin/blob/1.0.0-beta2/client/src/legacy/GridField.js#L119