### PR TITLE
FIX Import Closure class for type checking, and only set sort if the sort field exists

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -3,6 +3,7 @@
 namespace Symbiote\GridFieldExtensions;
 
 use Closure;
+use Exception;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse_Exception;
@@ -22,7 +23,6 @@ use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
 use SilverStripe\ORM\ManyManyList;
-use Exception;
 
 /**
  * Allows inline editing of grid field records without having to load a separate
@@ -145,7 +145,9 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
             // Check if we are also sorting these records
             if ($sortable) {
                 $sortField = $sortable->getSortField();
-                $item->setField($sortField, $fields[$sortField]);
+                if (isset($fields[$sortField])) {
+                    $item->setField($sortField, $fields[$sortField]);
+                }
             }
 
             if ($list instanceof ManyManyList) {


### PR DESCRIPTION
In `getFields` we check for an instance of Closure, which hasn't been imported yet so currently returns false:

```php
if ($info instanceof Closure) {
    $field = call_user_func($info, $record, $col, $grid);
} elseif // ...
```

Also adding a check for whether the field specified for sorting is available before trying to set it, this can prevent undefined index errors.