### PR TITLE
FIX When setting the page sizes, reset items per page to the first value

### DIFF
--- a/code/GridFieldConfigurablePaginator.php
+++ b/code/GridFieldConfigurablePaginator.php
@@ -159,6 +159,10 @@ class GridFieldConfigurablePaginator extends GridFieldPaginator
     public function setPageSizes(array $pageSizes)
     {
         $this->pageSizes = $pageSizes;
+
+        // Reset items per page
+        $this->setItemsPerPage(current($pageSizes));
+
         return $this;
     }
 

--- a/tests/GridFieldConfigurablePaginatorTest.php
+++ b/tests/GridFieldConfigurablePaginatorTest.php
@@ -80,6 +80,20 @@ class GridFieldConfigurablePaginatorTest extends SapphireTest
         $this->assertSame(3, $paginator->getTotalPages());
     }
 
+    public function testItemsPerPageIsSetToFirstInPageSizesListWhenChanged()
+    {
+        $paginator = new GridFieldConfigurablePaginator(20, array(20, 40, 60));
+        $paginator->setGridField($this->gridField);
+
+        // Initial state, should be what was provided to the constructor
+        $this->assertSame(20, $paginator->getItemsPerPage());
+
+        $paginator->setPageSizes(array(50, 100, 200));
+
+        // Set via public API, should now be set to 50
+        $this->assertSame(50, $paginator->getItemsPerPage());
+    }
+
     public function testGetCurrentPreviousAndNextPages()
     {
         $paginator = new GridFieldConfigurablePaginator(20, array(20, 40, 60));


### PR DESCRIPTION
If you use the public API to set the page sizes, the items per page remains at the default value from the core paginator.