### PR TITLE
FIX New Travis configuration, linting and updating existing skipped unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,31 @@
-# See https://github.com/silverstripe/silverstripe-travis-support for setup details
-
-sudo: false
-
 language: php
 
-dist: precise
-
-php:
-  - 5.6
-  - 7.0
-  - 7.1
-
 env:
-  - DB=MYSQL CORE_RELEASE=4
-  - DB=PGSQL CORE_RELEASE=4
+  global:
+    - COMPOSER_ROOT_VERSION="4.0.x-dev"
+
+matrix:
+  include:
+    - php: 5.6
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1
+    - php: 7.0
+      env: DB=PGSQL PHPUNIT_TEST=1
+    - php: 7.1
+      env: DB=MYSQL PHPUNIT_COVERAGE_TEST=1
 
 before_script:
-  - composer self-update || true
-  - git clone git://github.com/silverstripe/silverstripe-travis-support.git ~/travis-support
-  - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
-  - cd ~/builds/ss
-  - composer install --prefer-dist --no-progress --no-suggest
-  - composer require silverstripe/versioned:1.x-dev --prefer-dist --no-progress --no-suggest
-  - composer dump-autoload --optimize
+  - phpenv rehash
+  - phpenv config-rm xdebug.ini
+
+  - composer validate
+  - composer require silverstripe/recipe-core 1.0.x-dev  --no-update
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
-  - vendor/bin/phpunit gridfieldextensions/tests
+  - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit tests/; fi
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=framework/phpcs.xml.dist src/ tests/ ; fi
+
+after_success:
+  - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
     },
     "autoload": {
         "psr-4": {
-            "Symbiote\\GridFieldExtensions\\": "src/"
+            "Symbiote\\GridFieldExtensions\\": "src/",
+            "Symbiote\\GridFieldExtensions\\Tests\\": "tests/"
         }
     },
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
         "silverstripe/framework": "~4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7"
+        "phpunit/phpunit": "^5.7",
+        "squizlabs/php_codesniffer": "^3.0",
+        "silverstripe/versioned": "^1@dev"
     },
     "extra": {
         "installer-name": "gridfieldextensions",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit bootstrap="framework/tests/bootstrap.php" colors="true">
+	<testsuite name="Default">
+		<directory>tests</directory>
+	</testsuite>
+
+	<filter>
+		<whitelist addUncoveredFilesFromWhitelist="true">
+			<directory suffix=".php">src/</directory>
+			<exclude>
+				<directory suffix=".php">tests/</directory>
+			</exclude>
+		</whitelist>
+	</filter>
+</phpunit>

--- a/src/GridFieldAddNewMultiClass.php
+++ b/src/GridFieldAddNewMultiClass.php
@@ -158,7 +158,7 @@ class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URL
         }
 
         $sanitised = array();
-        foreach($result as $class=>$title) {
+        foreach ($result as $class => $title) {
             $sanitised[$this->sanitiseClassName($class)] = $title;
         }
 

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -516,11 +516,11 @@ class GridFieldOrderableRows extends RequestHandler implements
             $sortTable = $this->getSortTable($list);
             $additionalSQL = '';
             $baseTable = $sortTable;
-            if(class_exists($sortTable)) {
+            if (class_exists($sortTable)) {
                 $baseTable = singleton($sortTable)->baseTable();
             }
             $isBaseTable = ($baseTable == $sortTable);
-            if(!$list instanceof ManyManyList && $isBaseTable){
+            if (!$list instanceof ManyManyList && $isBaseTable) {
                 $additionalSQL = ', "LastEdited" = NOW()';
             }
 
@@ -535,7 +535,7 @@ class GridFieldOrderableRows extends RequestHandler implements
                         $this->getSortTableClauseForIds($list, $id)
                     ));
 
-                    if(!$isBaseTable) {
+                    if (!$isBaseTable) {
                         DB::query(sprintf(
                             'UPDATE "%s" SET "LastEdited" = NOW() WHERE %s',
                             $baseTable,
@@ -570,11 +570,11 @@ class GridFieldOrderableRows extends RequestHandler implements
 
         $additionalSQL = '';
         $baseTable = $table;
-        if(class_exists($table)) {
+        if (class_exists($table)) {
             $baseTable = singleton($table)->baseTable();
         }
         $isBaseTable = ($baseTable == $table);
-        if(!$list instanceof ManyManyList && $isBaseTable){
+        if (!$list instanceof ManyManyList && $isBaseTable) {
             $additionalSQL = ', "LastEdited" = NOW()';
         }
 
@@ -591,7 +591,7 @@ class GridFieldOrderableRows extends RequestHandler implements
                 $this->getSortTableClauseForIds($list, $id)
             ));
 
-            if(!$isBaseTable) {
+            if (!$isBaseTable) {
                 DB::query(sprintf(
                     'UPDATE "%s" SET "LastEdited" = NOW() WHERE %s',
                     $baseTable,

--- a/tests/GridFieldAddNewMultiClassTest.php
+++ b/tests/GridFieldAddNewMultiClassTest.php
@@ -1,9 +1,14 @@
 <?php
 
+namespace Symbiote\GridFieldExtensions\Tests;
+
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\Forms\GridField\GridField;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubA;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubB;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubC;
 
 /**
  * Tests for {@link GridFieldAddNewMultiClass}.
@@ -14,59 +19,32 @@ class GridFieldAddNewMultiClassTest extends SapphireTest
     public function testGetClasses()
     {
         $grid = new GridField('TestGridField');
-        $grid->setModelClass('GridFieldAddNewMultiClassTest_A');
+        $grid->setModelClass(StubA::class);
 
         $component = new GridFieldAddNewMultiClass();
 
         $this->assertEquals(
             array(
-                'GridFieldAddNewMultiClassTest_A' => 'A',
-                'GridFieldAddNewMultiClassTest_B' => 'B',
-                'GridFieldAddNewMultiClassTest_C' => 'C'
+                'Symbiote-GridFieldExtensions-Tests-Stub-StubA' => 'A',
+                'Symbiote-GridFieldExtensions-Tests-Stub-StubB' => 'B',
+                'Symbiote-GridFieldExtensions-Tests-Stub-StubC' => 'C'
             ),
             $component->getClasses($grid),
             'Subclasses are populated by default and sorted'
         );
 
         $component->setClasses(array(
-            'GridFieldAddNewMultiClassTest_B' => 'Custom Title',
-            'GridFieldAddNewMultiClassTest_A'
+            StubB::class => 'Custom Title',
+            StubA::class
         ));
 
         $this->assertEquals(
             array(
-                'GridFieldAddNewMultiClassTest_B' => 'Custom Title',
-                'GridFieldAddNewMultiClassTest_A' => 'A'
+                'Symbiote-GridFieldExtensions-Tests-Stub-StubB' => 'Custom Title',
+                'Symbiote-GridFieldExtensions-Tests-Stub-StubA' => 'A'
             ),
             $component->getClasses($grid),
             'Sorting and custom titles can be specified'
         );
     }
 }
-
-/**#@+
- * @ignore
- */
-
-class GridFieldAddNewMultiClassTest_A implements TestOnly
-{
-    public function i18n_singular_name()
-    {
-        $class = get_class($this);
-        return substr($class, strpos($class, '_') + 1);
-    }
-
-    public function canCreate()
-    {
-        return true;
-    }
-}
-
-class GridFieldAddNewMultiClassTest_B extends GridFieldAddNewMultiClassTest_A implements TestOnly
-{
-}
-class GridFieldAddNewMultiClassTest_C extends GridFieldAddNewMultiClassTest_A implements TestOnly
-{
-}
-
-/**#@-*/

--- a/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
+++ b/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
@@ -13,54 +13,59 @@ use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClassHandler;
 
-class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest {
+class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest
+{
 
-	public function testGetClassesWithNamespaces() {
-		$grid = new GridField('TestGridField');
-		$grid->setModelClass('Symbiote\\Test\\NamespacedClass');
+    public function testGetClassesWithNamespaces()
+    {
+        $grid = new GridField('TestGridField');
+        $grid->setModelClass('Symbiote\\Test\\NamespacedClass');
 
-		$component = new GridFieldAddNewMultiClass();
+        $component = new GridFieldAddNewMultiClass();
 
-		$this->assertEquals(
-			array(
-				'Symbiote-Test-NamespacedClass' => 'NamespacedClass'
-			),
-			$component->getClasses($grid),
-			'Namespaced classes are sanitised'
-		);
-	}
+        $this->assertEquals(
+            array(
+                'Symbiote-Test-NamespacedClass' => 'NamespacedClass'
+            ),
+            $component->getClasses($grid),
+            'Namespaced classes are sanitised'
+        );
+    }
 
-	public function testHandleAddWithNamespaces() {
-		$grid = new GridField('TestGridField');
-		$grid->getConfig()->addComponent(new GridFieldDetailForm());
-		$grid->setModelClass('Symbiote\\Test\\NamespacedClass');
-		$grid->setForm(Form::create(Controller::create(), 'test', FieldList::create(), FieldList::create()));
+    public function testHandleAddWithNamespaces()
+    {
+        $grid = new GridField('TestGridField');
+        $grid->getConfig()->addComponent(new GridFieldDetailForm());
+        $grid->setModelClass('Symbiote\\Test\\NamespacedClass');
+        $grid->setForm(Form::create(Controller::create(), 'test', FieldList::create(), FieldList::create()));
 
-		$request = new HTTPRequest('POST', 'test');
-		$request->setRouteParams(array('ClassName' => 'Symbiote-Test-NamespacedClass'));
+        $request = new HTTPRequest('POST', 'test');
+        $request->setRouteParams(array('ClassName' => 'Symbiote-Test-NamespacedClass'));
 
-		$component = new GridFieldAddNewMultiClass();
-		$response = $component->handleAdd($grid, $request);
+        $component = new GridFieldAddNewMultiClass();
+        $response = $component->handleAdd($grid, $request);
 
-		$record = new \ReflectionProperty(GridFieldAddNewMultiClassHandler::class, 'record');
-		$record->setAccessible(true);
-		$this->assertInstanceOf('Symbiote\\Test\\NamespacedClass', $record->getValue($response));
-	}
-
+        $record = new \ReflectionProperty(GridFieldAddNewMultiClassHandler::class, 'record');
+        $record->setAccessible(true);
+        $this->assertInstanceOf('Symbiote\\Test\\NamespacedClass', $record->getValue($response));
+    }
 }
 
 /**#@+
  * @ignore
  */
 
-class NamespacedClass implements TestOnly {
-	public function i18n_singular_name() {
-		return 'NamespacedClass';
-	}
+class NamespacedClass implements TestOnly
+{
+    public function i18n_singular_name()
+    {
+        return 'NamespacedClass';
+    }
 
-	public function canCreate() {
-		return true;
-	}
+    public function canCreate()
+    {
+        return true;
+    }
 }
 
 /**#@-*/

--- a/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
+++ b/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Symbiote\Test;
+namespace Symbiote\GridFieldExtensions\Tests;
 
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
@@ -12,6 +12,7 @@ use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClass;
 use Symbiote\GridFieldExtensions\GridFieldAddNewMultiClassHandler;
+use Symbiote\GridFieldExtensions\Tests\Stub\NamespacedClass;
 
 class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest
 {
@@ -19,13 +20,13 @@ class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest
     public function testGetClassesWithNamespaces()
     {
         $grid = new GridField('TestGridField');
-        $grid->setModelClass('Symbiote\\Test\\NamespacedClass');
+        $grid->setModelClass(NamespacedClass::class);
 
         $component = new GridFieldAddNewMultiClass();
 
         $this->assertEquals(
             array(
-                'Symbiote-Test-NamespacedClass' => 'NamespacedClass'
+                'Symbiote-GridFieldExtensions-Tests-Stub-NamespacedClass' => 'NamespacedClass'
             ),
             $component->getClasses($grid),
             'Namespaced classes are sanitised'
@@ -36,36 +37,17 @@ class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest
     {
         $grid = new GridField('TestGridField');
         $grid->getConfig()->addComponent(new GridFieldDetailForm());
-        $grid->setModelClass('Symbiote\\Test\\NamespacedClass');
+        $grid->setModelClass(NamespacedClass::class);
         $grid->setForm(Form::create(Controller::create(), 'test', FieldList::create(), FieldList::create()));
 
         $request = new HTTPRequest('POST', 'test');
-        $request->setRouteParams(array('ClassName' => 'Symbiote-Test-NamespacedClass'));
+        $request->setRouteParams(array('ClassName' => 'Symbiote-GridFieldExtensions-Tests-Stub-NamespacedClass'));
 
         $component = new GridFieldAddNewMultiClass();
         $response = $component->handleAdd($grid, $request);
 
         $record = new \ReflectionProperty(GridFieldAddNewMultiClassHandler::class, 'record');
         $record->setAccessible(true);
-        $this->assertInstanceOf('Symbiote\\Test\\NamespacedClass', $record->getValue($response));
+        $this->assertInstanceOf(NamespacedClass::class, $record->getValue($response));
     }
 }
-
-/**#@+
- * @ignore
- */
-
-class NamespacedClass implements TestOnly
-{
-    public function i18n_singular_name()
-    {
-        return 'NamespacedClass';
-    }
-
-    public function canCreate()
-    {
-        return true;
-    }
-}
-
-/**#@-*/

--- a/tests/GridFieldConfigurablePaginatorTest.php
+++ b/tests/GridFieldConfigurablePaginatorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Symbiote\GridFieldExtensions\Tests;
+
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\GridField\GridField;

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -1,11 +1,15 @@
 <?php
 
+namespace Symbiote\GridFieldExtensions\Tests;
+
+use ReflectionMethod;
 use SilverStripe\Dev\SapphireTest;
-use SilverStripe\Dev\TestOnly;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
-use SilverStripe\ORM\DataObject;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubParent;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubSubclass;
 
 /**
  * Tests for the {@link GridFieldOrderableRows} component.
@@ -15,19 +19,13 @@ class GridFieldOrderableRowsTest extends SapphireTest
 
     protected $usesDatabase = true;
 
-    // protected static $fixture_file = 'GridFieldOrderableRowsTest.yml';
+    protected static $fixture_file = 'GridFieldOrderableRowsTest.yml';
 
-    protected $extraDataObjects = array(
-        'GridFieldOrderableRowsTest_Parent',
-        'GridFieldOrderableRowsTest_Ordered',
-        'GridFieldOrderableRowsTest_Subclass',
+    protected static $extra_dataobjects = array(
+        StubParent::class,
+        StubOrdered::class,
+        StubSubclass::class,
     );
-
-    public function setUp()
-    {
-        parent::setUp();
-        $this->markTestSkipped('Upgrade to 4.0: Needs to be re-implemented.');
-    }
 
     public function testReorderItems()
     {
@@ -35,7 +33,7 @@ class GridFieldOrderableRowsTest extends SapphireTest
         $reflection = new ReflectionMethod($orderable, 'executeReorder');
         $reflection->setAccessible(true);
 
-        $parent = $this->objFromFixture('GridFieldOrderableRowsTest_Parent', 'parent');
+        $parent = $this->objFromFixture(StubParent::class, 'parent');
 
         $config = new GridFieldConfig_RelationEditor();
         $config->addComponent($orderable);
@@ -71,70 +69,27 @@ class GridFieldOrderableRowsTest extends SapphireTest
     {
         $orderable = new GridFieldOrderableRows();
 
-        $parent = new GridFieldOrderableRowsTest_Parent();
+        $parent = new StubParent();
         $parent->write();
 
         $this->assertEquals(
-            'GridFieldOrderableRowsTest_Ordered',
+            'StubOrdered',
             $orderable->getSortTable($parent->MyHasMany())
         );
 
         $this->assertEquals(
-            'GridFieldOrderableRowsTest_Ordered',
+            'StubOrdered',
             $orderable->getSortTable($parent->MyHasManySubclass())
         );
 
         $this->assertEquals(
-            'GridFieldOrderableRowsTest_Ordered',
+            'StubOrdered',
             $orderable->getSortTable($parent->MyManyMany())
         );
 
         $this->assertEquals(
-            'GridFieldOrderableRowsTest_Parent_MyManyMany',
+            'StubParent_MyManyMany',
             $orderable->setSortField('ManyManySort')->getSortTable($parent->MyManyMany())
         );
     }
 }
-
-/**#@+
- * @ignore
- */
-
-class GridFieldOrderableRowsTest_Parent extends DataObject implements TestOnly
-{
-
-    private static $has_many = array(
-        'MyHasMany' => 'GridFieldOrderableRowsTest_Ordered',
-        'MyHasManySubclass' => 'GridFieldOrderableRowsTest_Subclass'
-    );
-
-    private static $many_many = array(
-        'MyManyMany' => 'GridFieldOrderableRowsTest_Ordered'
-    );
-
-    private static $many_many_extraFields = array(
-        'MyManyMany' => array('ManyManySort' => 'Int')
-    );
-}
-
-class GridFieldOrderableRowsTest_Ordered extends DataObject implements TestOnly
-{
-
-    private static $db = array(
-        'Sort' => 'Int'
-    );
-
-    private static $has_one = array(
-        'Parent' => 'GridFieldOrderableRowsTest_Parent'
-    );
-
-    private static $belongs_many_many =array(
-        'MyManyMany' => 'GridFieldOrderableRowsTest_Parent',
-    );
-}
-
-class GridFieldOrderableRowsTest_Subclass extends GridFieldOrderableRowsTest_Ordered implements TestOnly
-{
-}
-
-/**#@-*/

--- a/tests/GridFieldOrderableRowsTest.yml
+++ b/tests/GridFieldOrderableRowsTest.yml
@@ -1,22 +1,29 @@
-GridFieldOrderableRowsTest_Ordered:
+Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered:
   item1:
+    Sort: 1
   item2:
+    Sort: 2
   item3:
+    Sort: 3
   item4:
+    Sort: 4
   item5:
+    Sort: 5
   item6:
-GridFieldOrderableRowsTest_Parent:
+    Sort: 6
+
+Symbiote\GridFieldExtensions\Tests\Stub\StubParent:
   parent:
     MyManyMany:
-      - 0: =>GridFieldOrderableRowsTest_Ordered.item1
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item1:
         ManyManySort: 1
-      - 1: =>GridFieldOrderableRowsTest_Ordered.item2
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item2:
         ManyManySort: 1
-      - 2: =>GridFieldOrderableRowsTest_Ordered.item3
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item3:
         ManyManySort: 2
-      - 3: =>GridFieldOrderableRowsTest_Ordered.item4
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item4:
         ManyManySort: 2
-      - 4: =>GridFieldOrderableRowsTest_Ordered.item5
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item5:
         ManyManySort: 108
-      - 5: =>GridFieldOrderableRowsTest_Ordered.item6
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item6:
         ManyManySort: 108

--- a/tests/Stub/NamespacedClass.php
+++ b/tests/Stub/NamespacedClass.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use Silverstripe\Dev\TestOnly;
+
+class NamespacedClass implements TestOnly
+{
+    public function i18n_singular_name()
+    {
+        return 'NamespacedClass';
+    }
+
+    public function canCreate()
+    {
+        return true;
+    }
+}

--- a/tests/Stub/StubA.php
+++ b/tests/Stub/StubA.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+
+class StubA implements TestOnly
+{
+    public function i18n_singular_name()
+    {
+        $class = get_class($this);
+        return substr($class, -1);
+    }
+
+    public function canCreate()
+    {
+        return true;
+    }
+}

--- a/tests/Stub/StubB.php
+++ b/tests/Stub/StubB.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+
+class StubB extends StubA implements TestOnly
+{
+}

--- a/tests/Stub/StubC.php
+++ b/tests/Stub/StubC.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+
+class StubC extends StubA implements TestOnly
+{
+}

--- a/tests/Stub/StubOrdered.php
+++ b/tests/Stub/StubOrdered.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class StubOrdered extends DataObject implements TestOnly
+{
+    private static $db = array(
+        'Sort' => 'Int'
+    );
+
+    private static $has_one = array(
+        'Parent' => StubParent::class
+    );
+
+    private static $belongs_many_many =array(
+        'MyManyMany' => StubParent::class,
+    );
+
+    private static $table_name = 'StubOrdered';
+}

--- a/tests/Stub/StubParent.php
+++ b/tests/Stub/StubParent.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class StubParent extends DataObject implements TestOnly
+{
+    private static $has_many = array(
+        'MyHasMany' => StubOrdered::class,
+        'MyHasManySubclass' => StubSubclass::class
+    );
+
+    private static $many_many = array(
+        'MyManyMany' => StubOrdered::class
+    );
+
+    private static $many_many_extraFields = array(
+        'MyManyMany' => array('ManyManySort' => 'Int')
+    );
+
+    private static $table_name = 'StubParent';
+}

--- a/tests/Stub/StubSubclass.php
+++ b/tests/Stub/StubSubclass.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class StubSubclass extends StubOrdered implements TestOnly
+{
+    private static $table_name = 'StubSubclass';
+}


### PR DESCRIPTION
SilverStripe is encouraging modules to move away from travis-support on SilverStripe 4, so this PR adds a standalone Travis config. I've updated the existing tests that were skipped, added an autoloader and namespace for the test classes and run a linter over it so the (new) PHPCS linter in Travis will pass.