### PR TITLE
BUG Fix casting for ‘$Attributes’

### DIFF
--- a/src/GridFieldAddNewInlineButton.php
+++ b/src/GridFieldAddNewInlineButton.php
@@ -144,8 +144,10 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
                     sprintf('[%s][{%%=o.num%%}]', self::POST_KEY),
                     $content
                 );
+            }
 
-                // Cast content as HTML
+            // Cast content
+            if (! $content instanceof DBField) {
                 $content = DBField::create_field('HTMLFragment', $content);
             }
 
@@ -157,7 +159,7 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 
             $columns->push(new ArrayData(array(
                 'Content'    => $content,
-                'Attributes' => $attrs,
+                'Attributes' => DBField::create_field('HTMLFragment', $attrs),
                 'IsActions'  => $column == 'Actions'
             )));
         }


### PR DESCRIPTION
@robbieaverill this fixes the incorrect drag-handle on new rows.

Before:

![image](https://user-images.githubusercontent.com/936064/30467328-fd8983d0-9a37-11e7-8c4e-a5ce799af81a.png)

After:

![image](https://user-images.githubusercontent.com/936064/30467309-dc82d59c-9a37-11e7-95af-f00dd8086781.png)
