### PR TITLE
Fix stopPropagation on click if no GridFieldEditableColumns

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -250,7 +250,7 @@
 		 * GridFieldEditableColumns
 		 */
 
-		$('.grid-field .ss-gridfield-item').entwine({
+		$('.ss-gridfield-editable .ss-gridfield-item').entwine({
 			onclick: function(e) {
 				// Prevent the default row click action when clicking a cell that contains a field
 				if (this.find('.editable-column-field').length) {


### PR DESCRIPTION
stopPropagation shouldn't fire if no GridFieldEditableColumns was added. It forces user to click on edit button on the far right instead of directly being able to click anywhere on the row.