### PR TITLE
FIX Remove excessive width on add new multi class dropdown

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -97,7 +97,6 @@
   display: inline-block;
   margin: 0;
   min-width: 150px;
-  width: calc(100% - 20px);
 }
 
 .ss-gridfield-add-new-multi-class .form-group:after {


### PR DESCRIPTION
This removes a width definition added in da2e75f: https://github.com/symbiote/silverstripe-gridfieldextensions/commit/da2e75f3c45e4fca5eae789015e924e5e1df5d8f#diff-0bb72c08bcda9f0d806610b70a0f6e7bR98

Resolves #229