### PR TITLE
Can't reorder many many versioned classes

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -531,8 +531,12 @@ class GridFieldOrderableRows extends RequestHandler implements
 
         // If not a ManyManyList and using versioning, detect it.
         $this->validateSortField($list);
+        $isVersioned = false;
         $class = $list->dataClass();
-        $isVersioned = $class::has_extension(Versioned::class);
+
+        if (DataObject::getSchema()->tableName($class) == $this->getSortTable($list)) {
+            $isVersioned = $class::has_extension(Versioned::class);
+        }
 
         // Loop through each item, and update the sort values which do not
         // match to order the objects.


### PR DESCRIPTION
Currently when updating a list of a many many versioned items the handleReorder method was going through the ORM process. Previously it had a `$isVersioned = false` variable set that would allow for this to go through the non ORM way. 

I've reverted back to how it previously was to fix this issue 