### PR TITLE
Inherited sort column on versioned data object reorder corrected

### DIFF
--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -9,8 +9,10 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubOrderedVersioned;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubParent;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubSubclass;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubUnorderable;
 
 /**
@@ -18,17 +20,22 @@ use Symbiote\GridFieldExtensions\Tests\Stub\StubUnorderable;
  */
 class GridFieldOrderableRowsTest extends SapphireTest
 {
-
-    protected $usesDatabase = true;
-
+    /**
+     * @var string
+     */
     protected static $fixture_file = 'GridFieldOrderableRowsTest.yml';
 
+    /**
+     * @var array
+     */
     protected static $extra_dataobjects = [
         StubParent::class,
         StubOrdered::class,
         StubSubclass::class,
         StubUnorderable::class,
         StubOrderableChild::class,
+        StubOrderedVersioned::class,
+        StubSubclassOrderedVersioned::class,
     ];
 
     public function testReorderItems()
@@ -125,5 +132,80 @@ class GridFieldOrderableRowsTest extends SapphireTest
             'StubParent_MyManyMany',
             $orderable->setSortField('ManyManySort')->getSortTable($parent->MyManyMany())
         );
+
+        $this->assertEquals(
+            'StubOrderedVersioned',
+            $orderable->setSortField('Sort')->getSortTable($parent->MyHasManySubclassOrderedVersioned())
+        );
+    }
+
+    public function testReorderItemsSubclassVersioned()
+    {
+        $orderable = new GridFieldOrderableRows('Sort');
+        $reflection = new ReflectionMethod($orderable, 'executeReorder');
+        $reflection->setAccessible(true);
+
+        $parent = $this->objFromFixture(StubParent::class, 'parent-subclass-ordered-versioned');
+
+        // make sure all items are published
+        foreach ($parent->MyHasManySubclassOrderedVersioned() as $item) {
+            $item->publishRecursive();
+        }
+
+        // there should be no difference between stages at this point
+        $differenceFound = false;
+        foreach ($parent->MyHasManySubclassOrderedVersioned() as $item) {
+            /** @var  StubSubclassOrderedVersioned|Versioned $item */
+            if ($item->stagesDiffer()) {
+                $differenceFound = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($differenceFound);
+
+        // reorder items
+        $config = new GridFieldConfig_RelationEditor();
+        $config->addComponent($orderable);
+
+        $grid = new GridField(
+            'TestField',
+            'TestField',
+            $parent->MyHasManySubclassOrderedVersioned()->sort('Sort', 'ASC'),
+            $config
+        );
+
+        $originalOrder = $parent->MyHasManySubclassOrderedVersioned()
+            ->sort('Sort', 'ASC')
+            ->column('ID');
+
+        $desiredOrder = [];
+
+        // Make order non-contiguous, and 1-based
+        foreach (array_reverse($originalOrder) as $index => $id) {
+            $desiredOrder[$index * 2 + 1] = $id;
+        }
+
+        $this->assertNotEquals($originalOrder, $desiredOrder);
+
+        $reflection->invoke($orderable, $grid, $desiredOrder);
+
+        $newOrder = $parent->MyHasManySubclassOrderedVersioned()
+            ->sort('Sort', 'ASC')
+            ->map('Sort', 'ID')
+            ->toArray();
+
+        $this->assertEquals($desiredOrder, $newOrder);
+
+        // reorder should have been handled as versioned - there should be a difference between stages now
+        $differenceFound = false;
+        foreach ($parent->MyHasManySubclassOrderedVersioned() as $item) {
+            if ($item->stagesDiffer()) {
+                $differenceFound = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($differenceFound);
     }
 }

--- a/tests/GridFieldOrderableRowsTest.yml
+++ b/tests/GridFieldOrderableRowsTest.yml
@@ -21,7 +21,26 @@ Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered:
   item6:
     Sort: 6
   nestedtest:
-    Children: =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item1,=>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item2,=>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item3,=>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item4
+    Children:
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item1
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item2
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item3
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrderableChild.item4
+
+Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned:
+  item1:
+    ExtraField: 1
+    Sort: 1
+  item2:
+    ExtraField: 2
+    Sort: 2
+  item3:
+    ExtraField: 3
+    Sort: 3
+  item4:
+    ExtraField: 4
+    Sort: 4
+
 Symbiote\GridFieldExtensions\Tests\Stub\StubParent:
   parent:
     MyManyMany:
@@ -37,3 +56,9 @@ Symbiote\GridFieldExtensions\Tests\Stub\StubParent:
         ManyManySort: 108
       - =>Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered.item6:
         ManyManySort: 108
+  parent-subclass-ordered-versioned:
+    MyHasManySubclassOrderedVersioned:
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned.item1
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned.item2
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned.item3
+      - =>Symbiote\GridFieldExtensions\Tests\Stub\StubSubclassOrderedVersioned.item4

--- a/tests/Stub/StubOrderedVersioned.php
+++ b/tests/Stub/StubOrderedVersioned.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class StubOrderedVersioned
+ * @package Symbiote\GridFieldExtensions\Tests\Stub
+ */
+class StubOrderedVersioned extends DataObject implements TestOnly
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'StubOrderedVersioned';
+
+    /**
+     * @var array
+     */
+    private static $extensions = [
+        Versioned::class,
+    ];
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'Sort' => 'Int',
+    ];
+}

--- a/tests/Stub/StubParent.php
+++ b/tests/Stub/StubParent.php
@@ -9,7 +9,8 @@ class StubParent extends DataObject implements TestOnly
 {
     private static $has_many = array(
         'MyHasMany' => StubOrdered::class,
-        'MyHasManySubclass' => StubSubclass::class
+        'MyHasManySubclass' => StubSubclass::class,
+        'MyHasManySubclassOrderedVersioned' => StubSubclassOrderedVersioned::class,
     );
 
     private static $many_many = array(

--- a/tests/Stub/StubSubclassOrderedVersioned.php
+++ b/tests/Stub/StubSubclassOrderedVersioned.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Versioned\Versioned;
+
+/**
+ * Class StubOrderedVersioned
+ * @package Symbiote\GridFieldExtensions\Tests\Stub
+ */
+class StubSubclassOrderedVersioned extends StubOrderedVersioned
+{
+    /**
+     * @var string
+     */
+    private static $table_name = 'StubSubclassOrderedVersioned';
+
+    /**
+     * @var array
+     */
+    private static $db = [
+        'ExtraField' => 'Int',
+    ];
+
+    /**
+     * @var array
+     */
+    private static $has_one = [
+        'Parent' => StubParent::class,
+    ];
+}


### PR DESCRIPTION
Corrected a case when sort column is located in a table that belongs to ancestor class of the item we are trying to reorder.

Fixes following setup:

`BaseItem` (is `Versioned`) - has the `Sort` column
`Item` (extends `BaseItem` and is `Versioned`) - is used as items in the list within `GridField`

Reorder action with the following setup would not detect that item is versioned.