### PR TITLE
FIX Orderable rows now respects actual MMTL sort orders instead of incrementing from SiteTree

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,11 @@ matrix:
     - php: 5.6
       env: DB=MYSQL RECIPE_VERSION=1.0.x-dev PHPCS_TEST=1 PHPUNIT_TEST=1
     - php: 7.0
-      env: DB=PGSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION=1.1.x-dev PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+      env: DB=PGSQL RECIPE_VERSION=4.2.x-dev PHPUNIT_COVERAGE_TEST=1
+    - php: 7.2
+      env: DB=MYSQL RECIPE_VERSION=4.3.x-dev PHPUNIT_TEST=1
     - php: 7.2
       env: DB=MYSQL RECIPE_VERSION=4.x-dev PHPUNIT_TEST=1
 
@@ -21,7 +23,7 @@ before_script:
 
   - composer validate
   - composer require silverstripe/recipe-core "$RECIPE_VERSION"  --no-update
-  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.0.x-dev --no-update; fi
+  - if [[ $DB == PGSQL ]]; then composer require silverstripe/postgresql:2.1.x-dev --no-update; fi
   - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -88,6 +88,40 @@ class GridFieldOrderableRowsTest extends SapphireTest
         $this->assertEquals($desiredOrder, $newOrder);
     }
 
+    public function testManyManyThroughListSortOrdersAreUsedForInitialRender()
+    {
+        /** @var ThroughDefiner $record */
+        $record = $this->objFromFixture(ThroughDefiner::class, 'DefinerOne');
+
+        $orderable = new GridFieldOrderableRows('Sort');
+        $config = new GridFieldConfig_RelationEditor();
+        $config->addComponent($orderable);
+
+        $grid = new GridField(
+            'Belongings',
+            'Testing Many Many',
+            $record->Belongings()->sort('Sort'),
+            $config
+        );
+
+        // Get the first record, which would be the first one to have column contents generated
+        /** @var ThroughIntermediary $expected */
+        $intermediary = $this->objFromFixture(ThroughIntermediary::class, 'One');
+
+        $result = $orderable->getColumnContent($grid, $record, 'irrelevant');
+
+        $this->assertContains(
+            'Belongings[GridFieldEditableColumns][' . $record->ID . '][Sort]',
+            $result,
+            'The field name is indexed under the record\'s ID'
+        );
+        $this->assertContains(
+            'value="' . $intermediary->Sort . '"',
+            $result,
+            'The value comes from the MMTL intermediary Sort value'
+        );
+    }
+
     public function testSortableChildClass()
     {
         $orderable = new GridFieldOrderableRows('Sort');

--- a/tests/OrderableRowsThroughVersionedTest.php
+++ b/tests/OrderableRowsThroughVersionedTest.php
@@ -12,7 +12,7 @@ use Symbiote\GridFieldExtensions\Tests\Stub\ThroughIntermediary;
 use Symbiote\GridFieldExtensions\Tests\Stub\ThroughBelongs;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
-class OrderableRowsThroughTest extends SapphireTest
+class OrderableRowsThroughVersionedTest extends SapphireTest
 {
     protected static $fixture_file = 'OrderableRowsThroughTest.yml';
 
@@ -105,7 +105,7 @@ class OrderableRowsThroughTest extends SapphireTest
             }
         }
         $this->assertTrue($differenceFound, 'All records should have changes in draft');
-        
+
         // Verify live stage has NOT reordered
         Versioned::set_stage(Versioned::LIVE);
         $sameOrder = $parent->$relationName()->sort($sortName)->column('ID');

--- a/tests/Stub/ThroughIntermediary.php
+++ b/tests/Stub/ThroughIntermediary.php
@@ -2,18 +2,17 @@
 
 namespace Symbiote\GridFieldExtensions\Tests\Stub;
 
-use SilverStripe\ORM\DataObject;
-use SilverStripe\ORM\FieldType\DBInt;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class ThroughIntermediary extends DataObject implements TestOnly
 {
     private static $table_name = 'IntermediaryThrough';
 
     private static $db = [
-        'Sort' => DBInt::class,
+        'Sort' => 'Int',
     ];
-    
+
     private static $has_one = [
         'Defining' => ThroughDefiner::class,
         'Belonging' => ThroughBelongs::class,


### PR DESCRIPTION
This fixes an error where reordering a many many through list would increment the sort order from the highest value in SiteTree (when `Sort` is the sort order on the MMTL relation model).

The error doesn't actually cause any problems with sorting, but the values it saves are not 1 based but come from the highest value in SiteTree.

This patch re-uses some existing logic to lookup the sort orders from the MMTL relationship table and use those instead, and centralises the logic in a way that both parts of the code can use it.

Fixes #268

---

Side note: this PR also fixes some broken doc blocks.