### PR TITLE
FIX Position inline editable checkbox fields relative rather than absolute

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -42,6 +42,11 @@
   background: #DFD;
 }
 
+.grid-field__table .form-check-input.editable-column-field {
+  margin-top: .9rem;
+  position: relative;
+}
+
 /**
  * GridFieldAddNewMultiClass
  */


### PR DESCRIPTION
Bootstrap positions them absolutely, while the container would have a relative position. This module isn't rendering the field holder, so this is a CSS patch to fix https://github.com/silverstripe/silverstripe-userforms/issues/821 instead