### PR TITLE
FIX: Prevent tmpl.js include on ajax request

### DIFF
--- a/code/GridFieldAddNewInlineButton.php
+++ b/code/GridFieldAddNewInlineButton.php
@@ -67,7 +67,9 @@ class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_S
 			throw new Exception('Inline adding requires the editable columns component');
 		}
 
-		Requirements::javascript(THIRDPARTY_DIR . '/javascript-templates/tmpl.js');
+		if (!Director::is_ajax()) {
+			Requirements::javascript(THIRDPARTY_DIR . '/javascript-templates/tmpl.js');
+		}
 		GridFieldExtensions::include_requirements();
 
 		$data = new ArrayData(array(


### PR DESCRIPTION
Including tmpl.js from the framework third party directory interfere with an upload field within a grid field edit form if the request is an Ajax request.

**Steps to replicate.**

1) Ensure you are in `test` mode
2) Ensure the  combined assets are cleared `./assets/_combinedfiles/`
3) Create a user defined form.
4) Add HTML block to the form.
5) Edit the HTML block and link text to a file.
6) Making a text linked to an internal document throws javascript error and upload field disappear.

First you see this JS error
![screen shot 2018-11-14 at 9 36 51 am](https://user-images.githubusercontent.com/166450/48441794-4674e280-e7f1-11e8-9a04-41f5ea0a4875.png)

After selecting a file
![screen shot 2018-11-14 at 9 37 18 am](https://user-images.githubusercontent.com/166450/48441793-45dc4c00-e7f1-11e8-9ed8-bd69c56d6d0c.png)

![screen shot 2018-11-14 at 9 37 25 am](https://user-images.githubusercontent.com/166450/48441791-45dc4c00-e7f1-11e8-85aa-f36d993c1a4b.png)

