### PR TITLE
Publish versioned objects on sort

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -648,6 +648,7 @@ class GridFieldOrderableRows extends RequestHandler implements
                 if ($record->$sortField != $newSortValue) {
                     $record->$sortField = $newSortValue;
                     $record->write();
+                    $record->doPublish();
                 }
             }
         }


### PR DESCRIPTION
When sorting versioned objects the sort value gets saved in the draft table, but not the _live table. This adds publishing for versioned objects.