### PR TITLE
FIX to make GridFieldOrderableRows support polymorphic ManyManyThroughList

### DIFF
--- a/tests/OrderablePolymorphicManyToMany.yml
+++ b/tests/OrderablePolymorphicManyToMany.yml
@@ -1,0 +1,28 @@
+Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MParent:
+  ParentOne:
+  ParentTwo:
+
+Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MChild:
+  ChildOne:
+  ChildTwo:
+
+Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MMapper:
+  MapP1ToC1:
+    Parent: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MParent.ParentOne'
+    Child: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MChild.ChildOne'
+    Sort: 1
+
+  MapP1ToC2:
+    Parent: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MParent.ParentOne'
+    Child: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MChild.ChildTwo'
+    Sort: 2
+
+  MapP2ToC1:
+    Parent: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MParent.ParentTwo'
+    Child: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MChild.ChildOne'
+    Sort: 2
+
+  MapP2ToC2:
+    Parent: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MParent.ParentTwo'
+    Child: '=>Symbiote\GridFieldExtensions\Tests\Stub\PolymorphM2MChild.ChildTwo'
+    Sort: 1

--- a/tests/Stub/PolymorphM2MChild.php
+++ b/tests/Stub/PolymorphM2MChild.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class PolymorphM2MChild extends DataObject implements TestOnly
+{
+    private static $table_name = 'TestOnly_PolymorphM2MChild';
+
+    private static $has_many = [
+        'Parents' => PolymorphM2MMapper::class
+    ];
+}

--- a/tests/Stub/PolymorphM2MMapper.php
+++ b/tests/Stub/PolymorphM2MMapper.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class PolymorphM2MMapper extends DataObject implements TestOnly
+{
+    private static $table_name = 'TestOnly_PolymorphM2MMapper';
+
+    private static $db = [
+        'Sort' => 'Int'
+    ];
+
+    private static $has_one = [
+        'Parent' => DataObject::class, // PolymorphM2MParent
+        'Child' => PolymorphM2MChild::class,
+    ];
+
+    private static $default_sort = '"Sort" ASC';
+}

--- a/tests/Stub/PolymorphM2MParent.php
+++ b/tests/Stub/PolymorphM2MParent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+class PolymorphM2MParent extends DataObject implements TestOnly
+{
+    private static $table_name = 'TableOnly_PolymorphM2MParent';
+
+    private static $many_many = [
+        'Children' => [
+            'through' => PolymorphM2MMapper::class,
+            'from' => 'Parent',
+            'to' => 'Child',
+        ]
+    ];
+}


### PR DESCRIPTION
The fix is for the issue
https://github.com/symbiote/silverstripe-gridfieldextensions/issues/295
To verify the fix, a reference of commits in core could be found:
https://github.com/silverstripe/silverstripe-framework/commit/257ff69e321e08af743de019ae338a291cb62615#diff-08f0e871daf5c0fd584acad12a119155R194