### PR TITLE
Fix support for dot notation in GridFieldOrderableRows

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -396,7 +396,12 @@ class GridFieldOrderableRows extends RequestHandler implements
         }
 
         // Get records from the `GridFieldEditableColumns` column
-        $data = $request->postVar($grid->getName());
+        $gridFieldName = $grid->getName();
+        if (strpos($gridFieldName, '.') !== false) {
+            $gridFieldName = str_replace('.', '_', $gridFieldName);
+        }
+
+        $data = $request->postVar($gridFieldName);
         $sortedIDs = $this->getSortedIDs($data);
         if (!$this->executeReorder($grid, $sortedIDs)) {
             $this->httpError(400);


### PR DESCRIPTION
When you want to have a GridField for a sub-relation on a relation of your DataObject you use dot notation, this breaks the functionality of GridFieldOrderableRows because in the POST request the dot is replaced by an underscore.