### PR TITLE
FIX: Allow silverstirpe/tagfield in GridFieldEditableColumns

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -97,7 +97,6 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
         $value = $this->formatValue($grid, $record, $col, $value);
 
         $field->setName($this->getFieldName($field->getName(), $grid, $record));
-        $field->setValue($value);
 
         if ($field instanceof HtmlEditorField) {
             return $field->FieldHolder();


### PR DESCRIPTION
This change was necessary to get a silverstripe/tagfield to work inside a GridFieldEditableColumns list. The value was previously loaded correctly, and subsequently clobbered by this line.

From what I can see, the removal of this line doesn’t break anything
else, as the record content is loaded earlier in the call stack by
$form->loadDataFrom() in getForm().