### PR TITLE
FIX Reinstate previous field fetch logic as fallback

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -84,6 +84,12 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
             $value  = $grid->getDataFieldValue($record, $col);
             $field = $fields->dataFieldByName($col);
 
+            // Fall back to previous logic
+            if (!$field) {
+                $rel = (strpos($col, '.') === false); // field references a relation value
+                $field = ($rel) ? clone $fields->fieldByName($col) : new ReadonlyField($col);
+            }
+
             if (!$field) {
                 throw new Exception("Could not find the field '$col'");
             }


### PR DESCRIPTION
Fixes some cases where a field is not retrievable via `dataFieldByName()`.

Resolves [silverstripe/silverstripe-userforms#994](https://github.com/silverstripe/silverstripe-userforms/issues/994).