### PR TITLE
Add translation string for Toast message "Records reordered."

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -456,7 +456,10 @@ class GridFieldOrderableRows extends RequestHandler implements
             $this->httpError(400);
         }
 
-        Controller::curr()->getResponse()->addHeader('X-Status', rawurlencode('Records reordered.'));
+        Controller::curr()->getResponse()->addHeader(
+            'X-Status',
+            rawurlencode(_t(__CLASS__ . '.REORDERED', 'Records reordered.'))
+        );
         return $grid->FieldHolder();
     }
 


### PR DESCRIPTION
Added a translation string for the toast message "Records reordered.".

This message is shown when the GridFieldOrableRows "handReorder" method is called.

I have provided translations for all of the available language files. Please note that these words are translated through Google Translate and therefore might not be 100% correct.

## Issues
- https://github.com/symbiote/silverstripe-gridfieldextensions/issues/378