### PR TITLE
🐛 (cms interface) applies default sort order to CMS ordering

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -364,11 +364,10 @@ class GridFieldOrderableRows extends RequestHandler implements
 
                 if ($list instanceof DataList) {
                     $classname = $list->dataClass();
-                    if (Config::inst()->get($classname, 'default_sort')) {
+                    if ($defaultSort = Config::inst()->get($classname, 'default_sort')) {
                         // Append the default sort to the end of the sort string
                         // This may result in redundancy... but it seems to work
-                        $sortterm .= $sortterm ? ', ' : '';
-                        $sortterm .= Config::inst()->get($classname, 'default_sort');
+                        $sortterm .= ($sortterm ? ', ' : '') . $defaultSort;
                     }
                 }
             }

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -8,6 +8,7 @@ use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse_Exception;
 use SilverStripe\Control\RequestHandler;
 use SilverStripe\Core\ClassInfo;
+use SilverStripe\Core\Config\Config;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridField_DataManipulator;
@@ -359,7 +360,15 @@ class GridFieldOrderableRows extends RequestHandler implements
                 // Fix bug in 3.1.3+ where ArrayList doesn't account for quotes
                 $sortterm .= $this->getSortTable($list).'.'.$this->getSortField();
             } else {
+                // If not an ArrayList it's definitely a DataList right?
+                // Or do we need another conditional here?
                 $sortterm .= '"'.$this->getSortTable($list).'"."'.$this->getSortField().'"';
+                $classname = $list->dataClass(); // DataLists have a dataClass
+                if (Config::inst()->get($list->dataClass(), 'default_sort')) {
+                    // Append the default sort to the end of the sort string
+                    // This may result in redundancy... but it seems to work
+                    $sortterm .= ', ' . Config::inst()->get($classname, 'default_sort');
+                }
             }
             return $list->sort($sortterm);
         }

--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -360,16 +360,19 @@ class GridFieldOrderableRows extends RequestHandler implements
                 // Fix bug in 3.1.3+ where ArrayList doesn't account for quotes
                 $sortterm .= $this->getSortTable($list).'.'.$this->getSortField();
             } else {
-                // If not an ArrayList it's definitely a DataList right?
-                // Or do we need another conditional here?
                 $sortterm .= '"'.$this->getSortTable($list).'"."'.$this->getSortField().'"';
-                $classname = $list->dataClass(); // DataLists have a dataClass
-                if (Config::inst()->get($list->dataClass(), 'default_sort')) {
-                    // Append the default sort to the end of the sort string
-                    // This may result in redundancy... but it seems to work
-                    $sortterm .= ', ' . Config::inst()->get($classname, 'default_sort');
+
+                if ($list instanceof DataList) {
+                    $classname = $list->dataClass();
+                    if (Config::inst()->get($classname, 'default_sort')) {
+                        // Append the default sort to the end of the sort string
+                        // This may result in redundancy... but it seems to work
+                        $sortterm .= $sortterm ? ', ' : '';
+                        $sortterm .= Config::inst()->get($classname, 'default_sort');
+                    }
                 }
             }
+
             return $list->sort($sortterm);
         }
 


### PR DESCRIPTION
This allows secondary sort ordering to be applied when it exists and when the objects have not been sorted manually.

This attempts to address #324. It could use some sanity checks and testing, but it is working as needed in my application. It was an open question to me whether this was the best way to address it or whether additional sort fields should be applied via a similar mechanism as what exists for `$extraSortFields`. My preference was for the component to automatically pick up on default sorts, but applying sort through another method would make sense to me too.