### PR TITLE
NEW Extend new AbstractGridFieldComponent class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "silverstripe/vendor-plugin": "^1.0",
-        "silverstripe/framework": "^4.10"
+        "silverstripe/framework": "^4.11"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -9,7 +9,7 @@ existing records than a basic autocomplete. It uses the search context construct
 class to provide the search form.
 
 ```php
-$grid->getConfig()->addComponent(new GridFieldAddExistingSearchButton());
+$grid->getConfig()->addComponent(GridFieldAddExistingSearchButton::create());
 ```
 
 Inline Editing
@@ -19,17 +19,17 @@ This example replaces the default data columns component with an inline editable
 default add new button with one that adds new records inline.
 
 ```php
-$grid = new GridField(
+$grid = GridField::create(
 	'ExampleGrid',
 	'Example Grid',
 	$this->Items(),
 	GridFieldConfig::create()
-		->addComponent(new GridFieldButtonRow('before'))
-		->addComponent(new GridFieldToolbarHeader())
-		->addComponent(new GridFieldTitleHeader())
-		->addComponent(new GridFieldEditableColumns())
-		->addComponent(new GridFieldDeleteAction())
-		->addComponent(new GridFieldAddNewInlineButton())
+		->addComponent(GridFieldButtonRow::create('before'))
+		->addComponent(GridFieldToolbarHeader::create())
+		->addComponent(GridFieldTitleHeader::create())
+		->addComponent(GridFieldEditableColumns::create())
+		->addComponent(GridFieldDeleteAction::create())
+		->addComponent(GridFieldAddNewInlineButton::create())
 );
 ```
 
@@ -39,7 +39,7 @@ inline editing component. By default field scaffolding will be used.
 ```php
 $grid->getConfig()->getComponentByType(GridFieldEditableColumns::class)->setDisplayFields(array(
 	'FirstField'  => function($record, $column, $grid) {
-		return new TextField($column);
+		return TextField::create($column);
 	},
 	'SecondField' => array(
 		'title' => 'Custom Title',
@@ -69,7 +69,7 @@ use SilverStripe\Forms\GridField\GridFieldAddNewButton;
 
 $grid->getConfig()
      ->removeComponentsByType(GridFieldAddNewButton::class)
-     ->addComponent(new GridFieldAddNewMultiClass());
+     ->addComponent(GridFieldAddNewMultiClass::create());
 ```
 
 Orderable Rows
@@ -82,10 +82,10 @@ the relationship.
 
 ```php
 // Basic usage, defaults to "Sort" for the sort field.
-$grid->getConfig()->addComponent(new GridFieldOrderableRows());
+$grid->getConfig()->addComponent(GridFieldOrderableRows::create());
 
 // Specifying the sort field.
-$grid->getConfig()->addComponent(new GridFieldOrderableRows('SortField'));
+$grid->getConfig()->addComponent(GridFieldOrderableRows::create('SortField'));
 ```
 
 By default, when you create a new item, it is created with a sort order of "0" - that is, it is added
@@ -118,7 +118,7 @@ To use this component you should remove the original paginator component first:
 ```php
 $gridField->getConfig()
     ->removeComponentsByType('GridFieldPaginator')
-    ->addComponent(new GridFieldConfigurablePaginator());
+    ->addComponent(GridFieldConfigurablePaginator::create());
 ```
 
 You can configure the page sizes with the configuration system. Note that merging is the default strategy, so to replace
@@ -133,7 +133,7 @@ Config::inst()->update('GridFieldConfigurablePaginator', 'default_page_sizes', a
 You can also override these at call time:
 
 ```php
-$paginator = new GridFieldConfigurablePaginator(100, array(100, 200, 500));
+$paginator = GridFieldConfigurablePaginator::create(100, array(100, 200, 500));
 
 $paginator->setPageSizes(array(200, 500, 1000));
 $paginator->setItemsPerPage(500);

--- a/src/GridFieldAddExistingSearchButton.php
+++ b/src/GridFieldAddExistingSearchButton.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\GridFieldExtensions;
 
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\Forms\GridField\GridField_URLHandler;
 use SilverStripe\ORM\SS_List;
@@ -11,7 +12,9 @@ use SilverStripe\View\ArrayData;
  * A modal search dialog which uses search context to search for and add
  * existing records to a grid field.
  */
-class GridFieldAddExistingSearchButton implements GridField_HTMLProvider, GridField_URLHandler
+class GridFieldAddExistingSearchButton extends AbstractGridFieldComponent implements
+    GridField_HTMLProvider,
+    GridField_URLHandler
 {
 
     private static $allowed_actions = array(
@@ -111,6 +114,6 @@ class GridFieldAddExistingSearchButton implements GridField_HTMLProvider, GridFi
 
     public function handleSearch($grid, $request)
     {
-        return new GridFieldAddExistingSearchHandler($grid, $this);
+        return GridFieldAddExistingSearchHandler::create($grid, $this);
     }
 }

--- a/src/GridFieldAddNewInlineButton.php
+++ b/src/GridFieldAddNewInlineButton.php
@@ -5,6 +5,7 @@ namespace Symbiote\GridFieldExtensions;
 use SilverStripe\Core\Convert;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\Forms\GridField\GridField_SaveHandler;
@@ -21,7 +22,9 @@ use Exception;
 /**
  * Builds on the {@link GridFieldEditableColumns} component to allow creating new records.
  */
-class GridFieldAddNewInlineButton implements GridField_HTMLProvider, GridField_SaveHandler
+class GridFieldAddNewInlineButton extends AbstractGridFieldComponent implements
+    GridField_HTMLProvider,
+    GridField_SaveHandler
 {
     /**
      * @skipUpgrade

--- a/src/GridFieldAddNewMultiClass.php
+++ b/src/GridFieldAddNewMultiClass.php
@@ -9,6 +9,7 @@ use SilverStripe\Core\ClassInfo;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Forms\DropdownField;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\Forms\GridField\GridField_URLHandler;
@@ -23,7 +24,9 @@ use Exception;
  * By default the list of classes that are createable is the grid field's model class, and any
  * subclasses. This can be customised using {@link setClasses()}.
  */
-class GridFieldAddNewMultiClass implements GridField_HTMLProvider, GridField_URLHandler
+class GridFieldAddNewMultiClass extends AbstractGridFieldComponent implements
+    GridField_HTMLProvider,
+    GridField_URLHandler
 {
     /**
      * @skipUpgrade

--- a/src/GridFieldTitleHeader.php
+++ b/src/GridFieldTitleHeader.php
@@ -2,6 +2,7 @@
 
 namespace Symbiote\GridFieldExtensions;
 
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\View\ArrayData;
@@ -9,7 +10,7 @@ use SilverStripe\View\ArrayData;
 /**
  * A simple header which displays column titles.
  */
-class GridFieldTitleHeader implements GridField_HTMLProvider
+class GridFieldTitleHeader extends AbstractGridFieldComponent implements GridField_HTMLProvider
 {
 
     public function getHTMLFragments($grid)


### PR DESCRIPTION
This makes this module's `GridFieldComponent` classes `Injectable`, and allows any future enhancements in the new abstract class to automatically apply without requiring additional changes in this module.

The class is introduced in silverstripe/framework 4.11.0 (see silverstripe/silverstripe-framework#10204) so the dependency constraint needs to be updated.

Also update docs to encourage use of dependency injection.