### PR TITLE
Allow publishing of already published versioned objects for 3.4 branch

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -57,6 +57,14 @@ $grid->getConfig()->getComponentByType('GridFieldEditableColumns')->setDisplayFi
 Editing data contained in `many_many_extraFields` is supported - just treat it as you would any
 other field.
 
+**Please note:** If you are using a GridFieldConfig that is scaffolded by GridField by default,
+and adding GridFieldEditableColumns into it, you will probably want to add it before the edit and/or
+delete buttons:
+
+```php
+$gridFieldConfig->addComponent($editableColumns, GridFieldEditButton::class);
+```
+
 Multi Class Adding
 ------------------
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -114,6 +114,19 @@ class Item extends DataObject {
 }
 ```
 
+### Versioning
+By default `GridFieldOrderableRows` will handle versioning but won't automatically publish any records. The user will need to go into each record and publish them manually which could get cumbersome for large lists.
+
+You can configure the list to automatically publish a record if the record is the latest version and is already published. This won't publish any records which have draft changes.
+
+```php
+$orderable = new GridFieldOrderableRows()
+    ->setRepublishLiveRecords(true);
+```
+
+There are caveats with both approaches so consideration should be made for which approach best suits the requirements.
+
+
 **Please NOTE:** There is a limitation when using `GridFieldOrderableRows` on unsaved data objects; namely, that it doesn't work as without data being saved, the list of related objects has no context. Please check `$this->ID` before adding the `GridFieldOrderableRows` component to the grid field config (or even, before adding the gridfield at all). 
 
 Configurable Paginator


### PR DESCRIPTION
Similiar to #339 just for the `3.4` branch

--- 


The change here https://github.com/symbiote/silverstripe-gridfieldextensions/pull/289 looks like it was merged to master by mistake.

This is opened to allow a 3.4.n a release bump