### PR TITLE
fixes GridFieldEditableColumns::isChanged method for non-string value…

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -339,7 +339,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
     private function isChanged(DataObject $item, array $fields): bool
     {
         foreach ($fields as $name => $value) {
-            if ((string) $item->getField($name) !== (string) $value) {
+            if ($item->getField($name) !== $value) {
                 return true;
             }
         }


### PR DESCRIPTION
…s (e.g. arrays for has_many / many_many relations)

This problem seems to emerge since SilverStripe 4.11.