### PR TITLE
NEW Control components written on GridFieldEditableColumns::handleSave

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -54,6 +54,33 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
      */
     protected $forms = array();
 
+    /**
+     * @see DataObject::write
+     * @see DataObject::writeComponents
+     * @see DataObject::skipWriteComponents
+     *
+     * @var bool|array
+     */
+    private $skipWriteComponents = true;
+
+    /**
+     * @return bool|array
+     */
+    public function getSkipWriteComponents()
+    {
+        return $this->skipWriteComponents;
+    }
+
+    /**
+     * @param bool|array $skipConfig
+     * @return $this
+     */
+    public function setSkipWriteComponents($skipConfig)
+    {
+        $this->skipWriteComponents = $skipConfig;
+        return $this;
+    }
+
     public function getColumnContent($grid, $record, $col)
     {
         $fields = $this->getForm($grid, $record)->Fields();
@@ -160,7 +187,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
                 $extra = array_intersect_key($form->getData(), (array) $list->getExtraFields());
             }
 
-            $item->write(false, false, false, true);
+            $item->write(false, false, false, $this->getSkipWriteComponents());
             $list->add($item, $extra);
         }
     }


### PR DESCRIPTION
Many objects contain a link back to the parent object (by nature of has_many), the same object that is being saved and triggering the GridFieldComponent to save its relational components in turn. This is often unnecessary and creates a 2N scenario for each record in the list, affecting performance. Especially when other onBefore/After/During write hooks are hanging off that class (e.g. fulltext search updates).

E.g.
```
Page:
  has_many:
    Things: Thing
```

Action: Save Page

bad execution flow:

Write Thing1
=>Write Page
Write Thing2
=>Write Page
Write Page


good execution flow:

Write Thing1
Write Thing2
Write Page

In order to have the opportunity to allow components to perform the second, this PR adds API.
