### PR TITLE
Make link color white.

### DIFF
--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -215,7 +215,7 @@
 
 }
 .grid-field-inline-new--multi-class-list a {
-  color: #FFF;
+  color: #FFF !important;
   display: block;
   margin: 5px -10px;
   padding: 0 10px;


### PR DESCRIPTION
There is a regression where the Add new record popup link is now blue. 
This update overwrites the SilverStripe style (/resources/vendor/silverstripe/admin/client/dist/styles/bundle.css)
```css
.ui-widget-content a, .ui-widget.ui-widget-content a, .ui-widget a {
    color: #0071c4;
}
```

Before:
![Screenshot from 2023-12-19 13-48-08](https://github.com/symbiote/silverstripe-gridfieldextensions/assets/36352093/15d3f30a-e88a-4c15-8daf-83eb8baca629)

After:
![Screenshot from 2023-12-19 13-48-17](https://github.com/symbiote/silverstripe-gridfieldextensions/assets/36352093/9857eec1-9f9d-4a8e-81fc-fb30c5aaecf8)