### PR TITLE
NEW Nested gridfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This module provides a number of useful grid field components:
   features.
 * `GridFieldTitleHeader` - a simple header which displays column titles.
 * `GridFieldConfigurablePaginator` - a paginator for GridField that allows customisable page sizes.
+* `GridFieldNestedForm` - allows nesting of GridFields for managing relation records directly within
+  a parent GridField.
 
 ## Installation
 

--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -223,3 +223,23 @@
 .grid-field-inline-new--multi-class-list__visible {
   display: block;
 }
+
+/**
+ * GridFieldNestedForm
+ */
+.grid-field tr.nested-gridfield td.gridfield-holder {
+  padding-left: 60px;
+}
+
+.grid-field.nested table tbody tr:not(.nested-gridfield) {
+  border-left: 1px solid #dbe0e9;
+}
+
+.grid-field.nested table tbody tr:not(.nested-gridfield).last {
+  border-bottom: 1px solid #dbe0e9;
+}
+
+.ss-gridfield-orderable.has-nested > .grid-field__table > .ss-gridfield-items > .ss-gridfield-item.ui-droppable-active.ui-state-highlight {
+  border: 0;
+  background-color: #fbf9ee;
+}

--- a/css/GridFieldExtensions.css
+++ b/css/GridFieldExtensions.css
@@ -231,6 +231,10 @@
   padding-left: 60px;
 }
 
+.grid-field.nested.empty-title .grid-field__title-row th {
+  padding: 0;
+}
+
 .grid-field.nested table tbody tr:not(.nested-gridfield) {
   border-left: 1px solid #dbe0e9;
 }

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -152,3 +152,17 @@ $paginator->setItemsPerPage(500);
 
 The first shown record will be maintained across page size changes, and the number of pages and current page will be
 recalculated on each request, based on the current first shown record and page size.
+
+Nested GridFields
+-----------------
+
+The `GridFieldNestedForm` component allows you to nest GridFields in the UI. It can be used with `DataObject` subclasses
+with the `Hierarchy` extension, or by specifying the relation used for nesting.
+
+```php
+// Basic usage, defaults to the Children-method for Hierarchy objects.
+$grid->getConfig()->addComponent(GridFieldNestedForm::create());
+
+// Usage with custom relation
+$grid->getConfig()->addComponent(GridFieldNestedForm::create()->setRelationName('MyRelation'));
+```

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -166,3 +166,32 @@ $grid->getConfig()->addComponent(GridFieldNestedForm::create());
 // Usage with custom relation
 $grid->getConfig()->addComponent(GridFieldNestedForm::create()->setRelationName('MyRelation'));
 ```
+
+You can define your own custom GridField config for the nested GridField configuration by implementing a `getNestedConfig`
+on your nested model (should return a `GridField_Config` object).
+```php
+class NestedObject extends DataObject
+{
+	private static $has_one = [
+		'Parent' => ParentObject::class
+	];
+
+	public function getNestedConfig(): GridFieldConfig
+	{
+		$config = new GridFieldConfig_RecordViewer();
+		return $config;
+	}
+}
+```
+
+You can also modify the default config (a `GridFieldConfig_RecordEditor`) via an extension to the nested model class, by implementing
+`updateNestedConfig`, which will get the config object as the first parameter.
+```php
+class NestedObjectExtension extends DataExtension
+{
+	public function updateNestedConfig(GridFieldConfig &$config)
+	{
+		$config->removeComponentsByType(GridFieldPaginator::class);
+	}
+}
+```

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -530,6 +530,13 @@
 				gridField.setState('GridFieldNestedForm', currState['GridFieldNestedForm']);
 				if (toggleState) {
 					if (!$(this).closest('tr').next('.nested-gridfield').length) {
+                        // add loading indicator until the nested gridfield is loaded
+                        let colspan = gridField.find('.grid-field__title-row th').attr('colspan');
+                        let loadingCell = $('<td />')
+                            .addClass('ss-gridfield-item loading')
+                            .attr('colspan', colspan);
+                        $(this).closest('tr').after($('<tr class="nested-gridfield" />').append(loadingCell));
+
 						let data = {};
 						let stateInput = gridField.find('input.gridstate').first();
 						data[stateInput.attr('name')] = JSON.stringify(currState);
@@ -633,7 +640,7 @@
 						let childID = ui.item.attr('data-id');
 						let parentIntoChild = $(e.target).closest('.grid-field[data-name*="[GridFieldNestedForm]['+childID+']"]').length;
 						if (parentIntoChild) {
-							// parent dragged into child, or widget dragged to root, cancel sorting
+							// parent dragged into child, cancel sorting
 							ui.sender.sortable("cancel");
 							e.preventDefault();
 							e.stopPropagation();

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -517,7 +517,7 @@
 		/**
 		 * GridFieldNestedForm
 		 */
-		$('.grid-field .col-listChildrenLink a').entwine({
+		$('.grid-field .col-listChildrenLink button').entwine({
 			onclick: function(e) {
 				let gridField = $(this).closest('.grid-field');
 				let currState = gridField.getState();
@@ -552,7 +552,7 @@
 						}
 						$.ajax({
 							type: 'POST',
-							url: $(this).attr('href'),
+							url: $(this).attr('data-url'),
 							data: data,
 							headers: {
 								'X-Pjax': pjaxTarget
@@ -572,6 +572,7 @@
 					}
 					$(this).removeClass('font-icon-right-dir');
 					$(this).addClass('font-icon-down-dir');
+					$(this).attr('aria-expanded', 'true');
 				}
 				else {
 					$.ajax({
@@ -580,6 +581,7 @@
 					$(this).closest('tr').next('.nested-gridfield').hide();
 					$(this).removeClass('font-icon-down-dir');
 					$(this).addClass('font-icon-right-dir');
+					$(this).attr('aria-expanded', 'false');
 				}
 				e.preventDefault();
 				e.stopPropagation();

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -1,4 +1,7 @@
 (function($) {
+	let preventReorderUpdate = false;
+	let updateTimeouts = [];
+
 	$.entwine("ss", function($) {
 		/**
 		 * GridFieldAddExistingSearchButton
@@ -612,8 +615,6 @@
 		$('.ss-gridfield-orderable.has-nested > .grid-field__table > tbody, .ss-gridfield-orderable.nested > .grid-field__table > tbody').entwine({
 			onadd: function() {
 				this._super();
-				let preventReorderUpdate = false;
-				let updateTimeouts = [];
 				let gridField = this.getGridField();
 				if (gridField.data("url-movetoparent")) {
 					let parentID = 0;

--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -612,6 +612,8 @@
 		$('.ss-gridfield-orderable.has-nested > .grid-field__table > tbody, .ss-gridfield-orderable.nested > .grid-field__table > tbody').entwine({
 			onadd: function() {
 				this._super();
+				let preventReorderUpdate = false;
+				let updateTimeouts = [];
 				let gridField = this.getGridField();
 				if (gridField.data("url-movetoparent")) {
 					let parentID = 0;
@@ -638,7 +640,7 @@
 							window.clearTimeout(timeout);
 						}
 						let childID = ui.item.attr('data-id');
-						let parentIntoChild = $(e.target).closest('.grid-field[data-name*="[GridFieldNestedForm]['+childID+']"]').length;
+						let parentIntoChild = $(e.target).closest('.grid-field[data-name*="-GridFieldNestedForm-'+childID+'"]').length;
 						if (parentIntoChild) {
 							// parent dragged into child, cancel sorting
 							ui.sender.sortable("cancel");

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -52,45 +52,78 @@ class GridFieldNestedForm extends GridFieldDetailForm implements
         $this->name = $name;
     }
     
+    /**
+     * Get the grid field that this component is attached to
+     * @return GridField
+     */
     public function getGridField()
     {
         return $this->gridField;
     }
 
+    /**
+     * Get the relation name to use for the nested grid fields
+     * @return string
+     */
     public function getRelationName()
     {
         return $this->relationName;
     }
     
+    /**
+     * Set the relation name to use for the nested grid fields
+     * @param string $relationName
+     */
     public function setRelationName($relationName)
     {
         $this->relationName = $relationName;
         return $this;
     }
 
+    /**
+     * Get whether the nested grid fields should be inline editable
+     * @return boolean
+     */
     public function getInlineEditable()
     {
         return $this->inlineEditable;
     }
 
+    /**
+     * Set whether the nested grid fields should be inline editable
+     * @param boolean $editable
+     */
     public function setInlineEditable($editable)
     {
         $this->inlineEditable = $editable;
         return $this;
     }
     
+    /**
+     * Set whether the nested grid fields should be expanded by default
+     * @param boolean $expandNested
+     */
     public function setExpandNested($expandNested)
     {
         $this->expandNested = $expandNested;
         return $this;
     }
 
+    /**
+     * Set whether the nested grid fields should be forced closed on load
+     * @param boolean $forceClosed
+     */
     public function setForceClosedNested($forceClosed)
     {
         $this->forceCloseNested = $forceClosed;
         return $this;
     }
 
+    /**
+     * Set a callback to check which items in this grid that should show the expand link
+     * for nested gridfields. The callback should return a boolean value.
+     * @param callable $checkFunction
+     */
     public function setCanExpandCheck($checkFunction)
     {
         $this->canExpandCheck = $checkFunction;
@@ -186,7 +219,7 @@ class GridFieldNestedForm extends GridFieldDetailForm implements
         if ($id) {
             // should be possible either on parent or child grid field, or nested grid field from parent
             $parent = $to ? $list->byID($to) : null;
-            if (!$parent && $to && $gridField->getForm()->getController() instanceof GridFieldNestedForm_ItemRequest && $gridField->getForm()->getController()->getRecord()->ID == $to) {
+            if (!$parent && $to && $gridField->getForm()->getController() instanceof GridFieldNestedFormItemRequest && $gridField->getForm()->getController()->getRecord()->ID == $to) {
                 $parent = $gridField->getForm()->getController()->getRecord();
             }
             $child = $list->byID($id);
@@ -248,7 +281,7 @@ class GridFieldNestedForm extends GridFieldDetailForm implements
         }
         $this->gridField = $gridField;
         $this->record = $record;
-        $itemRequest = new GridFieldNestedForm_ItemRequest($gridField, $this, $record, $gridField->getForm()->getController(), $this->name);
+        $itemRequest = GridFieldNestedFormItemRequest::create($gridField, $this, $record, $gridField->getForm()->getController(), $this->name);
         if ($request) {
             $pjaxFragment = $request->getHeader('X-Pjax');
             $targetPjaxFragment = str_replace('\\', '-', get_class($record)).'-'.$record->ID.'-'.$this->relationName;

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -104,27 +104,24 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
     
     /**
      * Get the grid field that this component is attached to
-     * @return GridField
      */
-    public function getGridField()
+    public function getGridField(): GridField
     {
         return $this->gridField;
     }
 
     /**
      * Get the relation name to use for the nested grid fields
-     * @return string
      */
-    public function getRelationName()
+    public function getRelationName(): string
     {
         return $this->relationName;
     }
     
     /**
      * Set the relation name to use for the nested grid fields
-     * @param string $relationName
      */
-    public function setRelationName($relationName)
+    public function setRelationName(string $relationName)
     {
         $this->relationName = $relationName;
         return $this;
@@ -132,18 +129,16 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     /**
      * Get whether the nested grid fields should be inline editable
-     * @return boolean
      */
-    public function getInlineEditable()
+    public function getInlineEditable(): bool
     {
         return $this->inlineEditable;
     }
 
     /**
      * Set whether the nested grid fields should be inline editable
-     * @param boolean $editable
      */
-    public function setInlineEditable($editable)
+    public function setInlineEditable(bool $editable)
     {
         $this->inlineEditable = $editable;
         return $this;
@@ -151,9 +146,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
     
     /**
      * Set whether the nested grid fields should be expanded by default
-     * @param boolean $expandNested
      */
-    public function setExpandNested($expandNested)
+    public function setExpandNested(bool $expandNested)
     {
         $this->expandNested = $expandNested;
         return $this;
@@ -161,9 +155,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     /**
      * Set whether the nested grid fields should be forced closed on load
-     * @param boolean $forceClosed
      */
-    public function setForceClosedNested($forceClosed)
+    public function setForceClosedNested(bool $forceClosed)
     {
         $this->forceCloseNested = $forceClosed;
         return $this;
@@ -173,9 +166,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
      * Set a callback function to check which items in this grid that should show the expand link
      * for nested gridfields. The callback should return a boolean value.
      * You can either pass a callable or a method name as a string.
-     * @param callable|string $callback
      */
-    public function setCanExpandCheck($callback)
+    public function setCanExpandCheck(callable|string $callback)
     {
         $this->canExpandCheck = $callback;
         return $this;
@@ -183,9 +175,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     /**
      * Set the maximum nesting level allowed for nested grid fields
-     * @param int $level
      */
-    public function setMaxNestingLevel($level)
+    public function setMaxNestingLevel(int $level)
     {
         $this->maxNestingLevel = $level;
         return $this;
@@ -193,16 +184,14 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     /**
      * Get the max nesting level allowed for this grid field.
-     * @return int
      */
-    public function getMaxNestingLevel()
+    public function getMaxNestingLevel(): int
     {
         return $this->maxNestingLevel ?: static::config()->get('default_max_nesting_level');
     }
 
     /**
      * Check if we are currently at the max nesting level allowed.
-     * @return bool
      */
     protected function atMaxNestingLevel(GridField $gridField): bool
     {
@@ -466,11 +455,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
     
     /**
      * Get the link for the nested grid field
-     *
-     * @param string $action
-     * @return string
      */
-    public function Link($action = null)
+    public function Link($action = null): string
     {
         $link = Director::absoluteURL(Controller::join_links($this->gridField->Link('nested'), $action));
         $manager = $this->getStateManager();
@@ -479,11 +465,8 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     /**
      * Get the link for the toggle action
-     *
-     * @param string $action
-     * @return string
      */
-    public function ToggleLink($action = null)
+    public function ToggleLink($action = null): string
     {
         $link = Director::absoluteURL(Controller::join_links($this->gridField->Link('toggle'), $action, '?toggle='));
         $manager = $this->getStateManager();

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -215,7 +215,7 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
             $this->gridField = $gridField;
             $relationName = $this->getRelationName();
             if (!$record->hasMethod($relationName)) {
-                return '';
+                throw new Exception('Invalid relation name');
             }
             if ($this->canExpandCallback) {
                 if (is_callable($this->canExpandCallback)

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -207,6 +207,9 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
 
     public function getColumnContent($gridField, $record, $columnName)
     {
+        if ($gridField->getConfig()->getComponentsByType(GridFieldNestedForm::class)->count() > 1) {
+            throw new Exception('Only one GridFieldNestedForm component allowed per GridField');
+        }
         if ($this->atMaxNestingLevel($gridField)) {
             return '';
         }

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -288,7 +288,7 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
         $list = $gridField->getList();
         $id = isset($move['id']) ? (int) $move['id'] : null;
         if (!$id) {
-            throw new HTTPResponse_Exception('Missing ID', 400);
+            throw new HTTPResponse_Exception('Missing ID', 404);
         }
         $to = isset($move['parent']) ? (int)$move['parent'] : null;
         // should be possible either on parent or child grid field, or nested grid field from parent

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -409,7 +409,7 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
         }
         $relationName = $this->getRelationName();
         if (!$record->hasMethod($relationName)) {
-            return '';
+            throw new Exception('Invalid relation name');
         }
         $manager = $this->getStateManager();
         $stateRequest = $request ?: $gridField->getForm()->getRequestHandler()->getRequest();

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -8,12 +8,15 @@ use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPResponse;
 use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Core\Extensible;
+use SilverStripe\Forms\GridField\AbstractGridFieldComponent;
 use SilverStripe\Forms\GridField\GridField;
-use SilverStripe\Forms\GridField\GridFieldDetailForm;
 use SilverStripe\Forms\GridField\GridField_ColumnProvider;
 use SilverStripe\Forms\GridField\GridField_DataManipulator;
 use SilverStripe\Forms\GridField\GridField_HTMLProvider;
 use SilverStripe\Forms\GridField\GridField_SaveHandler;
+use SilverStripe\Forms\GridField\GridField_URLHandler;
+use SilverStripe\Forms\GridField\GridFieldStateAware;
 use SilverStripe\ORM\DataList;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\DataObjectInterface;
@@ -26,12 +29,14 @@ use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 /**
  * Gridfield component for nesting GridFields
  */
-class GridFieldNestedForm extends GridFieldDetailForm implements
+class GridFieldNestedForm extends AbstractGridFieldComponent implements
+    GridField_URLHandler,
     GridField_ColumnProvider,
     GridField_SaveHandler,
     GridField_HTMLProvider,
     GridField_DataManipulator
 {
+    use Extensible, GridFieldStateAware;
     
     const POST_KEY = 'GridFieldNestedForm';
 
@@ -39,6 +44,10 @@ class GridFieldNestedForm extends GridFieldDetailForm implements
         'handleNestedItem'
     ];
     
+    /**
+     * @var string
+     */
+    protected $name;
     protected $expandNested = false;
     protected $forceCloseNested = false;
     protected $gridField = null;

--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -1,0 +1,330 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions;
+
+use Exception;
+use SilverStripe\Admin\ModelAdmin;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
+use SilverStripe\Control\HTTPResponse;
+use SilverStripe\Control\HTTPResponse_Exception;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Forms\GridField\GridField_ColumnProvider;
+use SilverStripe\Forms\GridField\GridField_DataManipulator;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\Forms\GridField\GridField_SaveHandler;
+use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\DataObjectInterface;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+use SilverStripe\ORM\SS_List;
+use SilverStripe\Versioned\Versioned;
+use SilverStripe\View\ViewableData;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
+
+/**
+ * Gridfield component for nesting GridFields
+ */
+class GridFieldNestedForm extends GridFieldDetailForm implements
+    GridField_ColumnProvider,
+    GridField_SaveHandler,
+    GridField_HTMLProvider,
+    GridField_DataManipulator
+{
+    
+    const POST_KEY = 'GridFieldNestedForm';
+
+    private static $allowed_actions = [
+        'handleNestedItem'
+    ];
+    
+    protected $expandNested = false;
+    protected $forceCloseNested = false;
+    protected $gridField = null;
+    protected $record = null;
+    protected $relationName = 'Children';
+    protected $inlineEditable = false;
+    protected $canExpandCheck = null;
+    
+    public function __construct($name = 'NestedForm')
+    {
+        $this->name = $name;
+    }
+    
+    public function getGridField()
+    {
+        return $this->gridField;
+    }
+
+    public function getRelationName()
+    {
+        return $this->relationName;
+    }
+    
+    public function setRelationName($relationName)
+    {
+        $this->relationName = $relationName;
+        return $this;
+    }
+
+    public function getInlineEditable()
+    {
+        return $this->inlineEditable;
+    }
+
+    public function setInlineEditable($editable)
+    {
+        $this->inlineEditable = $editable;
+        return $this;
+    }
+    
+    public function setExpandNested($expandNested)
+    {
+        $this->expandNested = $expandNested;
+        return $this;
+    }
+
+    public function setForceClosedNested($forceClosed)
+    {
+        $this->forceCloseNested = $forceClosed;
+        return $this;
+    }
+
+    public function setCanExpandCheck($checkFunction)
+    {
+        $this->canExpandCheck = $checkFunction;
+        return $this;
+    }
+
+    public function getColumnMetadata($gridField, $columnName)
+    {
+        return ['title' => ''];
+    }
+
+    public function getColumnsHandled($gridField)
+    {
+        return ['ToggleNested'];
+    }
+
+    public function getColumnAttributes($gridField, $record, $columnName)
+    {
+        return ['class' => 'col-listChildrenLink grid-field__col-compact'];
+    }
+
+    public function augmentColumns($gridField, &$columns)
+    {
+        if (!in_array('ToggleNested', $columns)) {
+            array_splice($columns, 0, 0, 'ToggleNested');
+        }
+    }
+
+    public function getColumnContent($gridField, $record, $columnName)
+    {
+        $gridField->addExtraClass('has-nested');
+        if ($record->ID && $record->exists()) {
+            $this->gridField = $gridField;
+            $this->record = $record;
+            $relationName = $this->getRelationName();
+            if (!$record->hasMethod($relationName)) {
+                return '';
+            }
+            if ($this->canExpandCheck) {
+                if (is_callable($this->canExpandCheck) && !call_user_func($this->canExpandCheck, $record)) {
+                    return '';
+                } elseif (is_string($this->canExpandCheck) && $record->hasMethod($this->canExpandCheck) && !$this->record->{$this->canExpandCheck}($record)) {
+                    return '';
+                }
+            }
+            $toggle = 'closed';
+            $className = str_replace('\\', '-', get_class($record));
+            $state = $gridField->State->GridFieldNestedForm;
+            $stateRelation = $className.'-'.$record->ID.'-'.$this->relationName;
+            if (!$this->forceCloseNested && (($this->expandNested && $record->$relationName()->count() > 0) || ($state && (int)$state->getData($stateRelation) === 1))) {
+                $toggle = 'open';
+            }
+
+            GridFieldExtensions::include_requirements();
+
+            return ViewableData::create()->customise([
+                'Toggle' => $toggle,
+                'Link' => $this->Link($record->ID),
+                'ToggleLink' => $this->ToggleLink($record->ID),
+                'PjaxFragment' => $stateRelation,
+                'NestedField' => ($toggle == 'open') ? $this->handleNestedItem($gridField, null, $record): ' '
+            ])->renderWith('Symbiote\GridFieldExtensions\GridFieldNestedForm');
+        }
+    }
+    
+    public function getURLHandlers($gridField)
+    {
+        return [
+            'nested/$RecordID/$NestedAction' => 'handleNestedItem',
+            'toggle/$RecordID' => 'toggleNestedItem',
+            'POST movetoparent' => 'handleMoveToParent'
+        ];
+    }
+
+    /**
+     * @param GridField $field
+     */
+    public function getHTMLFragments($field)
+    {
+        if (DataObject::has_extension($field->getModelClass(), Hierarchy::class)) {
+            $field->setAttribute('data-url-movetoparent', $field->Link('movetoparent'));
+        }
+    }
+
+    public function handleMoveToParent(GridField $gridField, $request)
+    {
+        $move = $request->postVar('move');
+        /** @var DataList */
+        $list = $gridField->getList();
+        $id = isset($move['id']) ? (int) $move['id'] : null;
+        $to = isset($move['parent']) ? (int)$move['parent'] : null;
+        $parent = null;
+        if ($id) {
+            // should be possible either on parent or child grid field, or nested grid field from parent
+            $parent = $to ? $list->byID($to) : null;
+            if (!$parent && $to && $gridField->getForm()->getController() instanceof GridFieldNestedForm_ItemRequest && $gridField->getForm()->getController()->getRecord()->ID == $to) {
+                $parent = $gridField->getForm()->getController()->getRecord();
+            }
+            $child = $list->byID($id);
+            if ($parent || $child || $to === 0) {
+                if (!$parent && $to) {
+                    $parent = DataList::create($gridField->getModelClass())->byID($to);
+                }
+                if (!$child) {
+                    $child = DataList::create($gridField->getModelClass())->byID($id);
+                }
+                if ($child) {
+                    if ($child->hasExtension(Hierarchy::class)) {
+                        $child->ParentID = $parent ? $parent->ID : 0;
+                    }
+                    $validationResult = $child->validate();
+                    if ($validationResult->isValid()) {
+                        if ($child->hasExtension(Versioned::class)) {
+                            $child->writeToStage(Versioned::DRAFT);
+                        } else {
+                            $child->write();
+                        }
+
+                        /** @var GridFieldOrderableRows */
+                        $orderableRows = $gridField->getConfig()->getComponentByType(GridFieldOrderableRows::class);
+                        if ($orderableRows) {
+                            $orderableRows->setImmediateUpdate(true);
+                            try {
+                                $orderableRows->handleReorder($gridField, $request);
+                            } catch (Exception $e) {
+                            }
+                        }
+                    } else {
+                        $messages = $validationResult->getMessages();
+                        $message = array_pop($messages);
+                        throw new HTTPResponse_Exception($message['message'], 400);
+                    }
+                }
+            }
+        }
+        return $gridField->FieldHolder();
+    }
+    
+    public function handleNestedItem(GridField $gridField, $request = null, $record = null)
+    {
+        if (!$record && $request) {
+            $recordID = $request->param('RecordID');
+            $record = $gridField->getList()->byID($recordID);
+        }
+        if (!$record) {
+            return '';
+        }
+        $relationName = $this->getRelationName();
+        if (!$record->hasMethod($relationName)) {
+            return '';
+        }
+        $manager = $this->getStateManager();
+        if ($gridStateStr = $manager->getStateFromRequest($gridField, $request ?: $gridField->getForm()->getRequestHandler()->getRequest())) {
+            $gridField->getState(false)->setValue($gridStateStr);
+        }
+        $this->gridField = $gridField;
+        $this->record = $record;
+        $itemRequest = new GridFieldNestedForm_ItemRequest($gridField, $this, $record, $gridField->getForm()->getController(), $this->name);
+        if ($request) {
+            $pjaxFragment = $request->getHeader('X-Pjax');
+            $targetPjaxFragment = str_replace('\\', '-', get_class($record)).'-'.$record->ID.'-'.$this->relationName;
+            if ($pjaxFragment == $targetPjaxFragment) {
+                $pjaxReturn = [$pjaxFragment => $itemRequest->ItemEditForm()->Fields()->first()->forTemplate()];
+                $response = new HTTPResponse(json_encode($pjaxReturn));
+                $response->addHeader('Content-Type', 'text/json');
+                return $response;
+            } else {
+                return $itemRequest->ItemEditForm();
+            }
+        } else {
+            return $itemRequest->ItemEditForm()->Fields()->first();
+        }
+    }
+
+    public function toggleNestedItem(GridField $gridField, $request = null, $record = null)
+    {
+        if (!$record) {
+            $recordID = $request->param('RecordID');
+            $record = $gridField->getList()->byID($recordID);
+        }
+        $manager = $this->getStateManager();
+        if ($gridStateStr = $manager->getStateFromRequest($gridField, $request)) {
+            $gridField->getState(false)->setValue($gridStateStr);
+        }
+        $className = str_replace('\\', '-', get_class($record));
+        $state = $gridField->getState()->GridFieldNestedForm;
+        $stateRelation = $className.'-'.$record->ID.'-'.$this->getRelationName();
+        $state->$stateRelation = (int)$request->getVar('toggle');
+    }
+    
+    public function Link($action = null)
+    {
+        $link = Director::absoluteURL(Controller::join_links($this->gridField->Link('nested'), $action));
+        $manager = $this->getStateManager();
+        return $manager->addStateToURL($this->gridField, $link);
+    }
+
+    public function ToggleLink($action = null)
+    {
+        $link = Director::absoluteURL(Controller::join_links($this->gridField->Link('toggle'), $action, '?toggle='));
+        $manager = $this->getStateManager();
+        return $manager->addStateToURL($this->gridField, $link);
+    }
+    
+    public function handleSave(GridField $gridField, DataObjectInterface $record)
+    {
+        $value = $gridField->Value();
+        if (!isset($value[self::POST_KEY]) || !is_array($value[self::POST_KEY])) {
+            return;
+        }
+
+        if (isset($value['GridState']) && $value['GridState']) {
+            // set grid state from value, to store open/closed toggle state for nested forms
+            $gridField->getState(false)->setValue($value['GridState']);
+        }
+        $manager = $this->getStateManager();
+        if ($gridStateStr = $manager->getStateFromRequest($gridField, $gridField->getForm()->getRequestHandler()->getRequest())) {
+            $gridField->getState(false)->setValue($gridStateStr);
+        }
+        foreach ($value[self::POST_KEY] as $recordID => $nestedData) {
+            $record = $gridField->getList()->byID($recordID);
+            if ($record) {
+                $nestedGridField = $this->handleNestedItem($gridField, null, $record);
+                $nestedGridField->setValue($nestedData);
+                $nestedGridField->saveInto($record);
+            }
+        }
+    }
+
+    public function getManipulatedData(GridField $gridField, SS_List $dataList)
+    {
+        if ($this->relationName == 'Children' && DataObject::has_extension($gridField->getModelClass(), Hierarchy::class) && $gridField->getForm()->getController() instanceof ModelAdmin) {
+            $dataList = $dataList->filter('ParentID', 0);
+        }
+        return $dataList;
+    }
+}

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -65,6 +65,10 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
             if ($relationClass == get_class($this->record)) {
                 $config->removeComponentsByType(GridFieldSortableHeader::class);
                 $config->removeComponentsByType(GridFieldFilterHeader::class);
+
+                if ($this->gridField->getConfig()->getComponentByType(GridFieldOrderableRows::class)) {
+                    $config->addComponent(new GridFieldOrderableRows());
+                }
             }
 
             if ($this->record->hasExtension(Hierarchy::class)) {
@@ -96,7 +100,7 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
         $fields = new FieldList(
             $gridField = new GridField(
                 sprintf(
-                    '%s[%s][%s]',
+                    '%s-%s-%s',
                     $this->component->getGridField()->getName(),
                     GridFieldNestedForm::POST_KEY,
                     $this->record->ID

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -72,7 +72,10 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
             }
 
             if ($this->record->hasExtension(Hierarchy::class)) {
-                $config->addComponent(new GridFieldNestedForm(), GridFieldOrderableRows::class);
+                $config->addComponent($nestedForm = new GridFieldNestedForm(), GridFieldOrderableRows::class);
+                // use max nesting level from parent component
+                $nestedForm->setMaxNestingLevel($this->component->getMaxNestingLevel());
+                
                 /** @var GridFieldOrderableRows */
                 $orderableRows = $config->getComponentByType(GridFieldOrderableRows::class);
                 if ($orderableRows) {

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -119,8 +119,6 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
         $gridField->setAttribute('data-class', str_replace('\\', '-', $relationClass));
         $gridField->addExtraClass('nested');
         $form = new Form($this, 'ItemEditForm', $fields, new FieldList());
-        $form->setStrictFormMethodCheck(false);
-        $form->disableSecurityToken();
 
         $className = str_replace('\\', '-', get_class($this->record));
         $state = $this->gridField->getState()->GridFieldNestedForm;

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -73,7 +73,7 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
                 }
             }
 
-            if ($this->record->hasExtension(Hierarchy::class)) {
+            if ($this->record->hasExtension(Hierarchy::class) && $relationClass == get_class($this->record)) {
                 $config->addComponent($nestedForm = new GridFieldNestedForm(), GridFieldOrderableRows::class);
                 // use max nesting level from parent component
                 $nestedForm->setMaxNestingLevel($this->component->getMaxNestingLevel());

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -46,7 +46,8 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
         $relationName = $this->component->getRelationName();
         $list = $this->record->$relationName();
         if ($relationName == 'Children' && $this->record->hasExtension(Hierarchy::class)) {
-            // we really need a HasManyList for Hierarchy objects, otherwise adding new items will not properly set the ParentID
+            // we really need a HasManyList for Hierarchy objects,
+            // otherwise adding new items will not properly set the ParentID
             $list = HasManyList::create(get_class($this->record), 'ParentID')
                         ->setDataQueryParam($this->record->getInheritableQueryParams())
                         ->forForeignID($this->record->ID);
@@ -93,7 +94,17 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
         $title = _t(get_class($this->record).'.'.strtoupper($relationName), ' ');
         
         $fields = new FieldList(
-            $gridField = new GridField($this->component->getGridField()->getName().'['.GridFieldNestedForm::POST_KEY.']['.$this->record->ID.']', $title, $list, $config)
+            $gridField = new GridField(
+                sprintf(
+                    '%s[%s][%s]',
+                    $this->component->getGridField()->getName(),
+                    GridFieldNestedForm::POST_KEY,
+                    $this->record->ID
+                ),
+                $title,
+                $list,
+                $config
+            )
         );
         if (!trim($title)) {
             $gridField->addExtraClass('empty-title');
@@ -137,7 +148,11 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
             ]));
         } else {
             $items->push(ArrayData::create([
-                'Title' => _t('SilverStripe\\Forms\\GridField\\GridField.NewRecord', 'New {type}', ['type' => $this->record->i18n_singular_name()]),
+                'Title' => _t(
+                    'SilverStripe\\Forms\\GridField\\GridField.NewRecord',
+                    'New {type}',
+                    ['type' => $this->record->i18n_singular_name()]
+                ),
                 'Link' => false
             ]));
         }

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -24,6 +24,9 @@ use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
+/**
+ * Request handler class for nested grid field forms.
+ */
 class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
 {
     public function Link($action = null)

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -21,7 +21,7 @@ use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
 use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
-class GridFieldNestedForm_ItemRequest extends GridFieldDetailForm_ItemRequest
+class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
 {
     
     public function Link($action = null)

--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -26,7 +26,6 @@ use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
 
 class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
 {
-    
     public function Link($action = null)
     {
         return Controller::join_links($this->component->Link($this->record->ID), $action);
@@ -75,7 +74,7 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
                 $config->addComponent($nestedForm = new GridFieldNestedForm(), GridFieldOrderableRows::class);
                 // use max nesting level from parent component
                 $nestedForm->setMaxNestingLevel($this->component->getMaxNestingLevel());
-                
+
                 /** @var GridFieldOrderableRows */
                 $orderableRows = $config->getComponentByType(GridFieldOrderableRows::class);
                 if ($orderableRows) {

--- a/src/GridFieldNestedForm_ItemRequest.php
+++ b/src/GridFieldNestedForm_ItemRequest.php
@@ -78,10 +78,15 @@ class GridFieldNestedForm_ItemRequest extends GridFieldDetailForm_ItemRequest
         }
 
         $this->record->invokeWithExtensions('updateNestedConfig', $config);
+
+        $title = _t(get_class($this->record).'.'.strtoupper($relationName), ' ');
         
         $fields = new FieldList(
-            $gridField = new GridField($this->component->getGridField()->getName().'['.GridFieldNestedForm::POST_KEY.']['.$this->record->ID.']', _t(get_class($this->record).'.'.strtoupper($relationName), ' '), $list, $config)
+            $gridField = new GridField($this->component->getGridField()->getName().'['.GridFieldNestedForm::POST_KEY.']['.$this->record->ID.']', $title, $list, $config)
         );
+        if (!trim($title)) {
+            $gridField->addExtraClass('empty-title');
+        }
         $gridField->setModelClass($relationClass);
         $gridField->setAttribute('data-class', str_replace('\\', '-', $relationClass));
         $gridField->addExtraClass('nested');

--- a/src/GridFieldNestedForm_ItemRequest.php
+++ b/src/GridFieldNestedForm_ItemRequest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions;
+
+use SilverStripe\Control\Controller;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
+use SilverStripe\Forms\GridField\GridFieldDataColumns;
+use SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest;
+use SilverStripe\Forms\GridField\GridFieldEditButton;
+use SilverStripe\Forms\GridField\GridFieldFilterHeader;
+use SilverStripe\Forms\GridField\GridFieldPageCount;
+use SilverStripe\Forms\GridField\GridFieldSortableHeader;
+use SilverStripe\ORM\ArrayList;
+use SilverStripe\ORM\HasManyList;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+use Symbiote\GridFieldExtensions\GridFieldAddNewInlineButton;
+use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
+use Symbiote\GridFieldExtensions\GridFieldOrderableRows;
+
+class GridFieldNestedForm_ItemRequest extends GridFieldDetailForm_ItemRequest
+{
+    
+    public function Link($action = null)
+    {
+        return Controller::join_links($this->component->Link($this->record->ID), $action);
+    }
+    
+    public function ItemEditForm()
+    {
+        $config = new GridFieldConfig_RecordEditor();
+        $relationName = $this->component->getRelationName();
+        $list = $this->record->$relationName();
+        if ($relationName == 'Children' && $this->record->hasExtension(Hierarchy::class)) {
+            // we really need a HasManyList for Hierarchy objects, otherwise adding new items will not properly set the ParentID
+            $list = HasManyList::create(get_class($this->record), 'ParentID')
+                        ->setDataQueryParam($this->record->getInheritableQueryParams())
+                        ->forForeignID($this->record->ID);
+        }
+        $relationClass = $list->dataClass();
+
+        if ($this->record->hasMethod('getNestedConfig')) {
+            $config = $this->record->getNestedConfig();
+        } else {
+            $canEdit = $this->record->canEdit();
+            if (!$canEdit) {
+                $config->removeComponentsByType(GridFieldAddNewButton::class);
+            }
+            $config->removeComponentsByType(GridFieldPageCount::class);
+            if ($relationClass == get_class($this->record)) {
+                $config->removeComponentsByType(GridFieldSortableHeader::class);
+                $config->removeComponentsByType(GridFieldFilterHeader::class);
+            }
+
+            if ($this->record->hasExtension(Hierarchy::class)) {
+                $config->addComponent(new GridFieldNestedForm(), GridFieldOrderableRows::class);
+                /** @var GridFieldOrderableRows */
+                $orderableRows = $config->getComponentByType(GridFieldOrderableRows::class);
+                if ($orderableRows) {
+                    $orderableRows->setReorderColumnNumber(1);
+                }
+            }
+
+            if ($this->component->getInlineEditable() && $canEdit) {
+                $config->removeComponentsByType(GridFieldDataColumns::class);
+                $config->addComponent(new GridFieldEditableColumns(), GridFieldEditButton::class);
+                $config->addComponent(new GridFieldAddNewInlineButton('buttons-before-left'));
+                $config->removeComponentsByType(GridFieldAddNewButton::class);
+                /** @var GridFieldNestedForm */
+                $nestedForm = $config->getComponentByType(GridFieldNestedForm::class);
+                if ($nestedForm) {
+                    $nestedForm->setInlineEditable(true);
+                }
+            }
+        }
+
+        $this->record->invokeWithExtensions('updateNestedConfig', $config);
+        
+        $fields = new FieldList(
+            $gridField = new GridField($this->component->getGridField()->getName().'['.GridFieldNestedForm::POST_KEY.']['.$this->record->ID.']', _t(get_class($this->record).'.'.strtoupper($relationName), ' '), $list, $config)
+        );
+        $gridField->setModelClass($relationClass);
+        $gridField->setAttribute('data-class', str_replace('\\', '-', $relationClass));
+        $gridField->addExtraClass('nested');
+        $form = new Form($this, 'ItemEditForm', $fields, new FieldList());
+        $form->setStrictFormMethodCheck(false);
+        $form->disableSecurityToken();
+
+        $className = str_replace('\\', '-', get_class($this->record));
+        $state = $this->gridField->getState()->GridFieldNestedForm;
+        if ($state) {
+            $stateRelation = $className.'-'.$this->record->ID.'-'.$relationName;
+            $state->$stateRelation = 1;
+        }
+
+        $this->record->extend('updateNestedForm', $form);
+        return $form;
+    }
+    
+    public function Breadcrumbs($unlinked = false)
+    {
+        if (!$this->popupController->hasMethod('Breadcrumbs')) {
+            return null;
+        }
+        
+        /** @var ArrayList $items */
+        $items = $this->popupController->Breadcrumbs($unlinked);
+        
+        $this->extend('updateBreadcrumbs', $items);
+        return $items;
+    }
+}

--- a/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
@@ -1,4 +1,10 @@
-<a class="btn btn-secondary btn--no-text btn--icon-large <% if $Toggle == 'open' %>font-icon-down-dir<% else %>font-icon-right-dir<% end_if %> cms-panel-link list-children-link" data-pjax-target="$PjaxFragment" href="$Link" data-toggle="$ToggleLink"></a>
+<button
+	class="btn btn-secondary btn--no-text btn--icon-large <% if $Toggle == 'open' %>font-icon-down-dir<% else %>font-icon-right-dir<% end_if %> cms-panel-link list-children-link"
+	aria-expanded="<% if $Toggle == 'open' %>true<% else %>false<% end_if %>"
+	data-pjax-target="$PjaxFragment"
+	data-url="$Link"
+	data-toggle="$ToggleLink"
+></button>
 <% if $Toggle == 'open' %>
 	$NestedField
 <% else %>

--- a/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
@@ -1,0 +1,6 @@
+<a class="btn btn-secondary btn--no-text btn--icon-large <% if $Toggle == 'open' %>font-icon-down-dir<% else %>font-icon-right-dir<% end_if %> cms-panel-link list-children-link" data-pjax-target="$PjaxFragment" href="$Link" data-toggle="$ToggleLink"></a>
+<% if $Toggle == 'open' %>
+	$NestedField
+<% else %>
+	<div class="nested-container" data-pjax-fragment="$PjaxFragment" style="display:none;"></div>
+<% end_if %>

--- a/tests/GridFieldNestedFormTest.php
+++ b/tests/GridFieldNestedFormTest.php
@@ -11,6 +11,8 @@ use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
 use SilverStripe\ORM\ArrayList;
 use Symbiote\GridFieldExtensions\GridFieldNestedForm;
 use Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubParent;
 use Symbiote\GridFieldExtensions\Tests\Stub\TestController;
 
 class GridFieldNestedFormTest extends SapphireTest
@@ -18,7 +20,9 @@ class GridFieldNestedFormTest extends SapphireTest
     protected static $fixture_file = 'GridFieldNestedFormTest.yml';
 
     protected static $extra_dataobjects = [
-        StubHierarchy::class
+        StubHierarchy::class,
+        StubParent::class,
+        StubOrdered::class
     ];
 
     public function testHierarchy()
@@ -54,5 +58,31 @@ class GridFieldNestedFormTest extends SapphireTest
         $this->assertEquals(1, $list->count());
         $child2 = $this->objFromFixture(StubHierarchy::class, 'item1_1_1');
         $this->assertEquals($child2->ID, $list->first()->ID);
+    }
+
+    public function testHasManyRelation()
+    {
+        // test that GridFieldNestedForm works with HasMany relations
+        $parent = $this->objFromFixture(StubParent::class, 'parent1');
+        $list = new ArrayList([$parent]);
+        $config = new GridFieldConfig_RecordEditor();
+        $config->addComponent($nestedForm = new GridFieldNestedForm());
+        $nestedForm->setRelationName('MyHasMany');
+
+        $controller = new TestController('Test');
+        $form = new Form($controller, 'TestForm', new FieldList(
+            $gridField = new GridField(__FUNCTION__, 'test', $list, $config)
+        ), new FieldList());
+
+        $request = new HTTPRequest('GET', '/');
+        $itemEditForm = $nestedForm->handleNestedItem($gridField, $request, $parent);
+        $this->assertNotNull($itemEditForm);
+        $nestedGridField = $itemEditForm->Fields()->first();
+        $this->assertNotNull($nestedGridField);
+        $list = $nestedGridField->getList();
+        $this->assertEquals(2, $list->count());
+
+        $child1 = $this->objFromFixture(StubOrdered::class, 'child1');
+        $this->assertEquals($child1->ID, $list->first()->ID);
     }
 }

--- a/tests/GridFieldNestedFormTest.php
+++ b/tests/GridFieldNestedFormTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests;
+
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor;
+use SilverStripe\ORM\ArrayList;
+use Symbiote\GridFieldExtensions\GridFieldNestedForm;
+use Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy;
+use Symbiote\GridFieldExtensions\Tests\Stub\TestController;
+
+class GridFieldNestedFormTest extends SapphireTest
+{
+    protected static $fixture_file = 'GridFieldNestedFormTest.yml';
+
+    protected static $extra_dataobjects = [
+        StubHierarchy::class
+    ];
+
+    public function testHierarchy()
+    {
+        // test that GridFieldNestedForm works with hierarchy objects
+        $parent = $this->objFromFixture(StubHierarchy::class, 'item1');
+        $list = new ArrayList([$parent]);
+        $config = new GridFieldConfig_RecordEditor();
+        $config->addComponent($nestedForm = new GridFieldNestedForm());
+
+        $controller = new TestController('Test');
+        $form = new Form($controller, 'TestForm', new FieldList(
+            $gridField = new GridField(__FUNCTION__, 'test', $list, $config)
+        ), new FieldList());
+
+        $request = new HTTPRequest('GET', '/');
+        $itemEditForm = $nestedForm->handleNestedItem($gridField, $request, $parent);
+        $this->assertNotNull($itemEditForm);
+        $nestedGridField = $itemEditForm->Fields()->first();
+        $this->assertNotNull($nestedGridField);
+        $list = $nestedGridField->getList();
+        $this->assertEquals(1, $list->count());
+
+        $child1 = $this->objFromFixture(StubHierarchy::class, 'item1_1');
+        $this->assertEquals($child1->ID, $list->first()->ID);
+        $nestedForm = $nestedGridField->getConfig()->getComponentByType(GridFieldNestedForm::class);
+        $itemEditForm = $nestedForm->handleNestedItem($gridField, $request, $child1);
+        $this->assertNotNull($itemEditForm);
+
+        $nestedGridField = $itemEditForm->Fields()->first();
+        $this->assertNotNull($nestedGridField);
+        $list = $nestedGridField->getList();
+        $this->assertEquals(1, $list->count());
+        $child2 = $this->objFromFixture(StubHierarchy::class, 'item1_1_1');
+        $this->assertEquals($child2->ID, $list->first()->ID);
+    }
+}

--- a/tests/GridFieldNestedFormTest.yml
+++ b/tests/GridFieldNestedFormTest.yml
@@ -1,0 +1,9 @@
+Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy:
+  item1: 
+    Title: 'Item 1'
+  item1_1:
+    Title: 'Item 1.1'
+    ParentID: =>Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy.item1
+  item1_1_1:
+    Title: 'Item 1.1.1'
+    ParentID: =>Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy.item1_1

--- a/tests/GridFieldNestedFormTest.yml
+++ b/tests/GridFieldNestedFormTest.yml
@@ -7,3 +7,13 @@ Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy:
   item1_1_1:
     Title: 'Item 1.1.1'
     ParentID: =>Symbiote\GridFieldExtensions\Tests\Stub\StubHierarchy.item1_1
+Symbiote\GridFieldExtensions\Tests\Stub\StubParent:
+  parent1:
+    Title: 'Parent 1'
+Symbiote\GridFieldExtensions\Tests\Stub\StubOrdered:
+  child1:
+    Title: 'Child 1'
+    ParentID: =>Symbiote\GridFieldExtensions\Tests\Stub\StubParent.parent1
+  child2:
+    Title: 'Child 2'
+    ParentID: =>Symbiote\GridFieldExtensions\Tests\Stub\StubParent.parent1

--- a/tests/Stub/StubHierarchy.php
+++ b/tests/Stub/StubHierarchy.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Symbiote\GridFieldExtensions\Tests\Stub;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\ORM\Hierarchy\Hierarchy;
+
+class StubHierarchy extends DataObject implements TestOnly
+{
+    private static $table_name = 'StubHierarchy';
+    
+    private static $extensions = [
+        Hierarchy::class
+    ];
+    
+    private static $db = [
+        'Title' => 'Varchar'
+    ];
+}


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->
Provides a `GridFieldComponent` for displaying a nested `GridField`, e.g. for `has_many` relations of the main record.

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->


Can be tested in a standard Silverstripe 5.1 installation in `SecurityAdmin` for editing groups, by adding the following extension to the project and adding it to `SecurityAdmin` via yaml config:

```php
<?php

namespace Creamarketing\NestedGridField;

use SilverStripe\Core\Extension;
use SilverStripe\Security\Group;
use Symbiote\GridFieldExtensions\GridFieldNestedForm;

class SecurityAdminExtension extends Extension
{
    public function updateGridFieldConfig($config)
    {
        if ($this->owner->getModelClass() === Group::class) {
            // shows nested groups
            $config->addComponent(GridFieldNestedForm::create());
            // Shows members in groups
            // $config->addComponent(GridFieldNestedForm::create()->setRelationName('Members'));
        }
    }
}
```

```yml
SilverStripe\Admin\SecurityAdmin:
  extensions:
    - Creamarketing\NestedGridField\SecurityAdminExtension
```

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- #383

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green