### PR TITLE
 DOC Correct spacing in YML example for nested gridfield 

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -230,7 +230,7 @@ class MySecurityAdminExtension extends Extension
 
 ```yml
 SilverStripe\Admin\SecurityAdmin:
-extensions:
+  extensions:
     - App\Extensions\MySecurityAdminExtension
 ```
 


### PR DESCRIPTION
## Parent issue
- https://github.com/symbiote/silverstripe-gridfieldextensions/issues/407