### PR TITLE
MNT Ignore phpstan error we can't fix

### DIFF
--- a/src/GridFieldNestedFormItemRequest.php
+++ b/src/GridFieldNestedFormItemRequest.php
@@ -103,6 +103,7 @@ class GridFieldNestedFormItemRequest extends GridFieldDetailForm_ItemRequest
 
         $this->record->invokeWithExtensions('updateNestedConfig', $config);
 
+        /** @phpstan-ignore translation.key (we need the key to be dynamic here) */
         $title = _t(get_class($this->record).'.'.strtoupper($relationName), ' ');
 
         $fields = new FieldList(


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-gridfieldextensions/actions/runs/10359119404/job/28674840945
> Can't determine value of first argument to _t(). Use a simpler value.

Intentionally targetting `4` - this code isn't on stable branches yet.

## Issue
- https://github.com/silverstripe/.github/issues/290