### PR TITLE
FIX #355 Sorting in paginated lists

### DIFF
--- a/src/GridFieldOrderableRows.php
+++ b/src/GridFieldOrderableRows.php
@@ -500,7 +500,7 @@ class GridFieldOrderableRows extends RequestHandler implements
         $move  = $request->postVar('move');
         $field = $this->getSortField();
 
-        $list  = $grid->getList();
+        $list  = $grid->getList()->sort($field);
         $manip = $grid->getManipulatedList();
 
         $existing = $manip->map('ID', $field)->toArray();


### PR DESCRIPTION
## Description
If a many_many relation with the sort in an many_many_extraField has an item dragged to another page the resulting sort is wrong. This was caused by the handleMoveToPage function not respecting the original sort of the list.

## Issues
- #355 

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
