### PR TITLE
MNT Fix broken behat test

### DIFF
--- a/tests/behat/features/hierarchical-nested-gridfield.feature
+++ b/tests/behat/features/hierarchical-nested-gridfield.feature
@@ -51,6 +51,7 @@ I want to see all children of hierarchical relational data in nested GridField
       And I should see "Tom" in the ".nested-gridfield.odd .ss-gridfield-item.last.even" element
       When I click on the ".nested-gridfield.odd .ss-gridfield-item.first.odd" element
       And I fill in "Name" with "John"
+      And I fill in "Email" with "john@example.com"
       And I press the "Save" button
       Then I click on the ".toolbar__back-button" element
       Then I click on the ".nested-gridfield.odd button[value='Surname']" element


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-gridfieldextensions/actions/runs/11095801859/job/30824884211

```text
And I should see "John" in the ".nested-gridfield.odd .ss-gridfield-item.last.even" element # SilverStripe\Framework\Tests\Behaviour\FeatureContext::assertElementContainsText()
The text "John" was not found in the text of the element matching css ".nested-gridfield.odd .ss-gridfield-item.last.even". (Behat\Mink\Exception\ElementTextException)
```

This got broken as a result of https://github.com/silverstripe/silverstripe-framework/pull/11395

## Issue
- https://github.com/silverstripe/.github/issues/313