### PR TITLE
MNT Fix behat test

### DIFF
--- a/tests/behat/features/configurable-paginator.feature
+++ b/tests/behat/features/configurable-paginator.feature
@@ -3,8 +3,8 @@ As a content editor
 I want to use the functionality in GridFieldConfigurablePaginator
 
   Background:
-    Given I add an extension "Symbiote\GridFieldExtensions\Tests\Stub\Extension\ConfigurablePaginatorExtension" to the "SilverStripe\FrameworkTest\Model\Company" class
-    And I add an extension "Symbiote\GridFieldExtensions\Tests\Stub\Extension\NoCoworkersExtension" to the "SilverStripe\FrameworkTest\Model\Employee" class
+    Given I add an extension "Symbiote\GridFieldExtensions\Tests\Stub\Extension\ConfigurablePaginatorExtension" to the "SilverStripe\FrameworkTest\Model\Company" class without dev-build
+    And I add an extension "Symbiote\GridFieldExtensions\Tests\Stub\Extension\NoCoworkersExtension" to the "SilverStripe\FrameworkTest\Model\Employee" class without dev-build
     And there are the following SilverStripe\FrameworkTest\Model\Employee records
     """
     employee1:


### PR DESCRIPTION
Fixes https://github.com/symbiote/silverstripe-gridfieldextensions/actions/runs/14869772137/job/41755320105

```text
And I click "Company One" in the "#Form_EditForm" element # SilverStripe\BehatExtension\Context\BasicContext::iClickInTheElement()
      "Company One" not found
      Failed asserting that null is not null.
```

In CMS 6 we have to explicitly state when we don't want dev-build since it can't just check for `DataExtension`.

## Issue

- https://github.com/symbiote/silverstripe-gridfieldextensions/issues/436