### PR TITLE
FIX Don't return invalid value

### DIFF
--- a/src/GridFieldNestedForm.php
+++ b/src/GridFieldNestedForm.php
@@ -367,7 +367,7 @@ class GridFieldNestedForm extends AbstractGridFieldComponent implements
             $record = $list->byID($recordID);
         }
         if (!$record) {
-            return '';
+            throw new HTTPResponse_Exception(statusCode: 404);
         }
         $relationName = $this->getRelationName();
         if (!$record->hasMethod($relationName)) {


### PR DESCRIPTION
If there's no record that should be a 404. Returning empty string is invalid for this method so would have been a 500!

## Issue

- https://github.com/silverstripe/silverstripe-gridfieldextensions/issues/449