### PR TITLE
FIX Remove invalid config

### DIFF
--- a/_config/gridfieldextensions.yml
+++ b/_config/gridfieldextensions.yml
@@ -1,9 +1,6 @@
 ---
 name: gridfieldextensions
 ---
-GridFieldAddNewMultiClass:
-  showEmptyString: true
-
 SilverStripe\Forms\GridField\GridFieldDetailForm_ItemRequest:
   extensions:
     - 'Symbiote\GridFieldExtensions\Extensions\GridFieldDetailFormItemRequestExtension'


### PR DESCRIPTION
The correct configuration is already applied as a `private static` property to the relevant class. See https://github.com/silverstripe/silverstripe-gridfieldextensions/blob/fcb9c46bca77bfb530efdb41a70551c84ce80033/src/GridFieldAddNewMultiClass.php#L38

## Issue

- https://github.com/silverstripe/silverstripe-gridfieldextensions/issues/454