### PR TITLE
ENH Hide font icons from screen readers

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -523,7 +523,7 @@
 				let currState = gridField.getState();
 				let toggleState = false;
 				let pjaxTarget = $(this).attr('data-pjax-target');
-				if ($(this).hasClass('font-icon-right-dir')) {
+				if ($(this).attr('aria-expanded') === 'false') {
 					toggleState = true;
 				}
 				if (typeof currState['GridFieldNestedForm'] == 'undefined' || currState['GridFieldNestedForm'] == null) {
@@ -568,23 +568,25 @@
 						$(this).closest('tr').next('.nested-gridfield').show();
 						fetch($(this).attr('data-toggle')+'1');
 					}
-					$(this).removeClass('font-icon-right-dir');
-					$(this).addClass('font-icon-down-dir');
 					$(this).attr('aria-expanded', 'true');
+					const icon = $(this).find('.nested-gridfield__toggle-icon');
+					icon.removeClass('font-icon-right-dir');
+					icon.addClass('font-icon-down-dir');
 				}
 				else {
 					fetch($(this).attr('data-toggle')+'0');
 					$(this).closest('tr').next('.nested-gridfield').hide();
-					$(this).removeClass('font-icon-down-dir');
-					$(this).addClass('font-icon-right-dir');
 					$(this).attr('aria-expanded', 'false');
+					const icon = $(this).find('.nested-gridfield__toggle-icon');
+					icon.removeClass('font-icon-down-dir');
+					icon.addClass('font-icon-right-dir');
 				}
 				e.preventDefault();
 				e.stopPropagation();
 				return false;
 			}
 		});
-		
+
 		// move nested gridfields onto their own rows below this row, to make it look nicer
 		$('.col-listChildrenLink > .grid-field.nested').entwine({
 			onadd: function() {

--- a/templates/Symbiote/GridFieldExtensions/GridFieldAddNewInlineButton.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldAddNewInlineButton.ss
@@ -1,3 +1,4 @@
-<button href="$Link" class="ss-gridfield-add-new-inline btn btn-primary font-icon-plus-circled">
+<button href="$Link" class="ss-gridfield-add-new-inline btn btn-primary">
+    <span class="font-icon-plus-circled" aria-hidden="true"></span>
 	$Title
 </button>

--- a/templates/Symbiote/GridFieldExtensions/GridFieldAddNewInlineRow.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldAddNewInlineRow.ss
@@ -3,7 +3,9 @@
 		<% loop $Me %>
 			<% if $IsActions %>
 				<td$Attributes>
-					<button class="ss-gridfield-delete-inline gridfield-button-delete action gridfield-button-delete btn--icon-md font-icon-trash-bin btn--no-text grid-field__icon-action form-group--no-label"></button>
+					<button class="ss-gridfield-delete-inline gridfield-button-delete action gridfield-button-delete btn--icon-md btn--no-text grid-field__icon-action form-group--no-label">
+                        <span class="font-icon-trash-bin" aria-hidden="true"></span>
+                    </button>
 				</td>
 			<% else %>
 				<td$Attributes>$Content</td>

--- a/templates/Symbiote/GridFieldExtensions/GridFieldAddNewMultiClass.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldAddNewMultiClass.ss
@@ -1,5 +1,8 @@
 <div class="ss-gridfield-add-new-multi-class">
 	$ClassField.FieldHolder
 
-	<a href="#" data-href="$Link" data-add-multiclass class="btn btn-primary font-icon-plus btn__addnewmulticlass" data-icon="add">$Title</a>
+	<a href="#" data-href="$Link" data-add-multiclass class="btn btn-primary btn__addnewmulticlass">
+        <span class="font-icon-plus" aria-hidden="true"></span>
+        $Title
+    </a>
 </div>

--- a/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldNestedForm.ss
@@ -1,10 +1,10 @@
 <button
-	class="btn btn-secondary btn--no-text btn--icon-large <% if $Toggle == 'open' %>font-icon-down-dir<% else %>font-icon-right-dir<% end_if %> cms-panel-link list-children-link"
+	class="btn btn-secondary btn--no-text btn--icon-large cms-panel-link list-children-link"
 	aria-expanded="<% if $Toggle == 'open' %>true<% else %>false<% end_if %>"
 	data-pjax-target="$PjaxFragment"
 	data-url="$Link"
 	data-toggle="$ToggleLink"
-></button>
+><span class="nested-gridfield__toggle-icon <% if $Toggle == 'open' %>font-icon-down-dir<% else %>font-icon-right-dir<% end_if %>" aria-hidden="true"></span></button>
 <% if $Toggle == 'open' %>
 	$NestedField
 <% else %>

--- a/templates/Symbiote/GridFieldExtensions/GridFieldOrderableRowsDragHandle.ss
+++ b/templates/Symbiote/GridFieldExtensions/GridFieldOrderableRowsDragHandle.ss
@@ -1,2 +1,2 @@
-<div class="handle"><i class="icon font-icon-drag-handle"></i></div>
+<div class="handle"><span class="icon font-icon-drag-handle" aria-hidden="true"></span></div>
 $SortField


### PR DESCRIPTION
- Updates JS to support icons in inner span elements
- Replaces any `<i>` being used as an icon with `span` for consistency and semantic correctness
- Hides decorative icons from screen readers (usually by adding an inner `span`)
- Remove `data-icon` attribute which resulted in a mangled icon after moving the font-icon class

Without the admin PR things look very slightly different, but it's still perfectly usable so I don't think it's worth updating the constraint.

## Issue

- https://github.com/silverstripe/silverstripe-admin/issues/1957