### PR TITLE
NEW Prepend new inline rows control

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -195,7 +195,7 @@
 
 				tmpl.cache[this[0].id + "ss-gridfield-add-inline-template"] = tmpl(row.html());
 
-				this.find("tbody:first").append(tmpl(this[0].id + "ss-gridfield-add-inline-template", { num: num }));
+				this.find("tbody:first").prepend(tmpl(this[0].id + "ss-gridfield-add-inline-template", { num: num }));
 				this.find("tbody:first").children(".ss-gridfield-no-items").hide();
 				this.data("add-inline-num", num + 1);
 


### PR DESCRIPTION
## Description
This changes new inline gridfield rows to be prepended to the start of the grid when added instead of appended to the end.

<img width="1387" height="349" alt="image" src="https://github.com/user-attachments/assets/4992d6a4-6dc0-43c8-a557-11badf65a080" />

## Manual testing steps

Add a few rows (if no rows exist yet). Save.

Refresh the page to ensure there are existing rows loaded. Press the add row button. The new row should appear on top.

## Issues
- https://github.com/silverstripe/silverstripe-gridfieldextensions/issues/331

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
