### PR TITLE
FIX Remove code that deals with non-existent legacy filter

### DIFF
--- a/javascript/GridFieldExtensions.js
+++ b/javascript/GridFieldExtensions.js
@@ -404,23 +404,6 @@
             // multiple relationships via keyboard.
             if (focusedElName) self.find(':input[name="' + focusedElName + '"]').focus();
 
-            // Update filter
-            if (self.find('.grid-field__filter-header').length) {
-              var content;
-              if (ajaxOpts.data[0].filter == "show") {
-                content = '<span class="non-sortable"></span>';
-                self.addClass('show-filter').find('.grid-field__filter-header').show();
-              } else {
-                const contentTitle = ss.i18n._t('GridFieldExtensions.OPEN_SEARCH_FILTER', 'Open search and filter');
-                content = `<button type="button" title="${contentTitle}" name="showFilter" class="btn btn-secondary btn--no-text btn--icon-large grid-field__filter-open">
-                  <span class="font-icon-search" aria-hidden="true"></span>
-                </button>`;
-                self.removeClass('show-filter').find('.grid-field__filter-header').hide();
-              }
-
-              self.find('.sortable-header th:last').html(content);
-            }
-
             // update CMS preview
             var preview = $('.cms-preview');
             if (preview.length) {


### PR DESCRIPTION
This functionality was related to the legacy filter header, which [was removed in CMS 5](https://github.com/silverstripe/silverstripe-framework/pull/10594/files#diff-2fc06c772b88d42f781cc14c5eed8d42f5c49e27478422371df628e4f1ad2826). It serves no purpose anymore.

## Issue

- https://github.com/silverstripe/silverstripe-framework/issues/11817