### PR TITLE
MNT Update unit tests for PHP 8.5

### DIFF
--- a/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
+++ b/tests/GridFieldAddNewMultiClassWithNamespacesTest.php
@@ -47,7 +47,6 @@ class GridFieldAddNewMultiClassWithNamespacesTest extends SapphireTest
         $response = $component->handleAdd($grid, $request);
 
         $record = new \ReflectionProperty(GridFieldAddNewMultiClassHandler::class, 'record');
-        $record->setAccessible(true);
         $this->assertInstanceOf(NamespacedClass::class, $record->getValue($response));
     }
 }

--- a/tests/GridFieldOrderableRowsTest.php
+++ b/tests/GridFieldOrderableRowsTest.php
@@ -81,8 +81,6 @@ class GridFieldOrderableRowsTest extends SapphireTest
     {
         $orderable = new GridFieldOrderableRows($sortName);
         $reflection = new ReflectionMethod($orderable, 'executeReorder');
-        $reflection->setAccessible(true);
-
         $config = new GridFieldConfig_RelationEditor();
         $config->addComponent($orderable);
 
@@ -185,8 +183,6 @@ class GridFieldOrderableRowsTest extends SapphireTest
     {
         $orderable = new GridFieldOrderableRows('Sort');
         $reflection = new ReflectionMethod($orderable, 'executeReorder');
-        $reflection->setAccessible(true);
-
         $parent = $this->objFromFixture(StubOrdered::class, 'nestedtest');
 
         $config = new GridFieldConfig_RelationEditor();
@@ -248,8 +244,6 @@ class GridFieldOrderableRowsTest extends SapphireTest
     {
         $orderable = new GridFieldOrderableRows('Sort');
         $reflection = new ReflectionMethod($orderable, 'executeReorder');
-        $reflection->setAccessible(true);
-
         $parent = $this->objFromFixture(StubParent::class, 'parent-subclass-ordered-versioned');
 
         // make sure all items are published

--- a/tests/OrderableRowsThroughVersionedTest.php
+++ b/tests/OrderableRowsThroughVersionedTest.php
@@ -55,8 +55,6 @@ class OrderableRowsThroughVersionedTest extends SapphireTest
 
         $orderable = new GridFieldOrderableRows($sortName);
         $reflection = new ReflectionMethod($orderable, 'executeReorder');
-        $reflection->setAccessible(true);
-
         $config = new GridFieldConfig_RelationEditor();
         $config->addComponent($orderable);
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/455

The following changes were made based on the [PHP 8.5 changelog](https://www.php.net/ChangeLog-8.php):

- The setAccessible() methods of various Reflection objects have been deprecated, as those no longer have an effect.
