### PR TITLE
fix error when getContainerFieldList() returns null

### DIFF
--- a/src/Extensions/GridFieldDetailFormItemRequestExtension.php
+++ b/src/Extensions/GridFieldDetailFormItemRequestExtension.php
@@ -28,9 +28,10 @@ class GridFieldDetailFormItemRequestExtension extends Extension
         $addMultiClassComponent = $gridFieldConfig->getComponentByType(GridFieldAddNewMultiClass::class);
         if ($addMultiClassComponent) {
             $newRecordField = static::get_new_record_field_from_actions($actions);
-            if ($newRecordField && ($container = $newRecordField->getContainerFieldList())) {
-                $container->removeByName('new-record');
-                $container->push(
+            if ($newRecordField) {
+                $containerField = $newRecordField->getContainerFieldList();
+                $containerField->removeByName('new-record');
+                $containerField->push(
                     LiteralField::create('new-record', $this->getHTMLFragment($addMultiClassComponent))
                 );
                 GridFieldExtensions::include_requirements();

--- a/src/Extensions/GridFieldDetailFormItemRequestExtension.php
+++ b/src/Extensions/GridFieldDetailFormItemRequestExtension.php
@@ -28,9 +28,9 @@ class GridFieldDetailFormItemRequestExtension extends Extension
         $addMultiClassComponent = $gridFieldConfig->getComponentByType(GridFieldAddNewMultiClass::class);
         if ($addMultiClassComponent) {
             $newRecordField = static::get_new_record_field_from_actions($actions);
-            if ($newRecordField) {
-                $newRecordField->getContainerFieldList()->removeByName('new-record');
-                $newRecordField->getContainerFieldList()->push(
+            if ($newRecordField && ($container = $newRecordField->getContainerFieldList())) {
+                $container->removeByName('new-record');
+                $container->push(
                     LiteralField::create('new-record', $this->getHTMLFragment($addMultiClassComponent))
                 );
                 GridFieldExtensions::include_requirements();


### PR DESCRIPTION
## Description
A change introduced in https://github.com/silverstripe/silverstripe-framework/commit/aa4f7458a4c7e58344d56ea1750a23bed70ced67 results in `getContainerFieldList()` returning null sometimes. This fix catches that.

## Issues
- #465 

## Pull request checklist
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
