### PR TITLE
FIX Control which components are written on GridFieldEditableColumns:::handleSave

### DIFF
--- a/src/GridFieldEditableColumns.php
+++ b/src/GridFieldEditableColumns.php
@@ -52,6 +52,33 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
      */
     protected $forms = array();
 
+    /**
+     * @see DataObject::write
+     * @see DataObject::writeComponents
+     * @see DataObject::skipWriteComponents
+     *
+     * @var bool|array
+     */
+    private $skipWriteComponents = true;
+
+    /**
+     * @return bool|array
+     */
+    public function getComponentWriteConfig()
+    {
+        return $this->skipWriteComponents;
+    }
+
+    /**
+     * @param bool|array $skipConfig
+     * @return $this
+     */
+    public function setComponentWriteConfig($skipConfig)
+    {
+        $this->skipWriteComponents = $skipConfig;
+        return $this;
+    }
+
     public function getColumnContent($grid, $record, $col)
     {
         $fields = $this->getForm($grid, $record)->Fields();
@@ -169,7 +196,7 @@ class GridFieldEditableColumns extends GridFieldDataColumns implements
                 $extra = array_intersect_key($form->getData() ?? [], (array) $list->getExtraFields());
             }
 
-            $item->write(false, false, false, true);
+            $item->write(false, false, false, $this->getComponentWriteConfig());
             $list->add($item, $extra);
         }
     }


### PR DESCRIPTION
## Description

**This is a copy of #422, which was refused because it wasn't attached to an issue...**

This PR covers the previous attempts at fixing this, see https://github.com/silverstripe/silverstripe-gridfieldextensions/pull/350, https://github.com/silverstripe/silverstripe-gridfieldextensions/pull/422 and https://github.com/silverstripe/silverstripe-gridfieldextensions/pull/437.

Child objects contain a link back to the parent object (e.g. a has_one back to the parent of a has_many relation).

When saving the parent object (say RecipePage), the child objects managed in a GridField with GridFieldEditableColumns are being saved. This in return causes the parent object (here the Recipe Page) to be saved again.

This results in the parent object being saved as many times as there are child objects, affecting performance. Especially when other onBefore/After/During write hooks are hanging off that class (e.g. fulltext search updates, etc).

## Manual testing steps

see #469

## Issues

- #469

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
